### PR TITLE
Fix GitHub OAuth login redirect 404 error

### DIFF
--- a/dockerfiles/Hub/templates/login.html
+++ b/dockerfiles/Hub/templates/login.html
@@ -149,8 +149,12 @@ AUP Learning Cloud
 
                 {% elif authenticator_mode == 'github' %}
                 <!-- GitHub OAuth Only -->
+                <!-- NOTE: Do NOT add "| urlencode" to OAuth links! JupyterHub already URL-escapes
+                     the "next" variable. OAuth stores next in a cookie as-is, so double-encoding
+                     causes redirects to fail (e.g., /hub/%2Fhub%2F instead of /hub/).
+                     Form POST actions DO need urlencode due to different browser/server handling. -->
                 <div class="mb-6">
-                    <a href="{{ base_url }}oauth_login?next={{ next | urlencode }}"
+                    <a href="{{ base_url }}oauth_login?next={{ next }}"
                        class="w-full flex justify-center items-center py-3 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-300">
                         <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd"/>
@@ -162,8 +166,9 @@ AUP Learning Cloud
                 {% else %}
                 <!-- Multi Authenticator: GitHub OAuth + Native accounts -->
                 <!-- GitHub OAuth Button -->
+                <!-- NOTE: Do NOT add "| urlencode" here - see comment above for explanation -->
                 <div class="mb-6">
-                    <a href="{{ base_url }}github/oauth_login?next={{ next | urlencode }}"
+                    <a href="{{ base_url }}github/oauth_login?next={{ next }}"
                        class="w-full flex justify-center items-center py-3 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-300">
                         <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd"/>


### PR DESCRIPTION
## Summary
- Remove `| urlencode` filter from GitHub OAuth login links to prevent double URL encoding
- JupyterHub's LoginHandler already applies `url_escape()` to the `next` parameter before passing it to templates
- Double encoding caused redirect URLs like `/hub/%2Fhub%2F` instead of `/hub/`

## Changes
- Line 153: GitHub-only mode OAuth link
- Line 166: Multi-authenticator mode GitHub OAuth link

Note: Native/dummy form actions still require `urlencode` as they handle encoding differently.

## Test plan
- [x] Test GitHub OAuth login with redirect from protected page (e.g., `/hub/admin`)
- [x] Verify redirect goes to correct page after login
- [x] Verify native login still works correctly