### PR TITLE
ci: enable GPU base image build on GitHub Actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,28 +21,104 @@ name: Build Docker Images
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
+    tags: ['v*']
     paths:
-      - 'runtime/Dockerfile/**'
       - 'dockerfiles/**'
+      - 'runtime/hub/**'
+      - 'projects/**'
+      - '.github/workflows/docker-build.yml'
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
-      - 'runtime/Dockerfile/**'
       - 'dockerfiles/**'
+      - 'runtime/hub/**'
+      - 'projects/**'
+      - '.github/workflows/docker-build.yml'
   workflow_dispatch:
     inputs:
-      override_versions:
-        description: 'Override all versions (leave empty to use default versions)'
-        required: false
       version:
-        description: 'Version tag (e.g. v1.6)'
+        description: 'Version tag for images (e.g. v1.2.0)'
+        required: false
+        default: ''
+      images:
+        description: 'Which images to build'
         required: true
-        default: 'v1.0'
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - hub
+          - courses
+          - base-cpu
+          - base-gpu
+
+# Prevent duplicate builds on the same branch / PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
+  # ──────────────────────────────────────────────
+  # Detect which files changed to decide what to build
+  # ──────────────────────────────────────────────
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      hub: ${{ steps.filter.outputs.hub }}
+      courses: ${{ steps.filter.outputs.courses }}
+      base-cpu: ${{ steps.filter.outputs.base-cpu }}
+      base-gpu: ${{ steps.filter.outputs.base-gpu }}
+      registry: ${{ steps.registry.outputs.prefix }}
+      is-tag: ${{ steps.check.outputs.is-tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set registry prefix
+        id: registry
+        run: echo "prefix=ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag push
+        id: check
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "is-tag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-tag=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: dorny/paths-filter@v3
+        if: github.ref_type != 'tag' && github.event_name != 'workflow_dispatch'
+        id: filter
+        with:
+          filters: |
+            hub:
+              - 'dockerfiles/Hub/**'
+              - 'runtime/hub/**'
+            courses:
+              - 'dockerfiles/Courses/**'
+              - 'dockerfiles/Base/**'
+              - 'projects/**'
+            base-cpu:
+              - 'dockerfiles/Base/Dockerfile.cpu'
+            base-gpu:
+              - 'dockerfiles/Base/Dockerfile.gfx1151'
+
+  # ──────────────────────────────────────────────
+  # Hub Image (CPU only, runs on GitHub Actions)
+  # ──────────────────────────────────────────────
   build-hub:
     name: Build Hub Image
+    needs: changes
+    if: |
+      needs.changes.outputs.is-tag == 'true' ||
+      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.hub == 'true') ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.images == 'all' || github.event.inputs.images == 'hub'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -52,37 +128,51 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.changes.outputs.registry }}/auplc-hub
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event.inputs.version != '' }}
+            type=sha,prefix=sha-
+            type=ref,event=branch
+            type=ref,event=pr
 
       - name: Build and push Hub image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: dockerfiles/Hub/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ghcr.io/amdresearch/auplc-hub:${{ github.event.inputs.override_versions || 'v1.2.0' }}
-            ghcr.io/amdresearch/auplc-hub:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=hub
+          cache-to: type=gha,mode=max,scope=hub
+          provenance: false
 
-  build-notebooks:
-    name: Build Notebook Images
+  # ──────────────────────────────────────────────
+  # Base CPU Image (runs on GitHub Actions)
+  # ──────────────────────────────────────────────
+  build-base-cpu:
+    name: Build Base CPU Image
+    needs: changes
+    if: |
+      needs.changes.outputs.is-tag == 'true' ||
+      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.base-cpu == 'true') ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.images == 'all' || github.event.inputs.images == 'base-cpu'))
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - docker_path: runtime/Dockerfile/Basic
-            image_name: aup-cpu-notebook
-            default_version: 'v1.0'
-          - docker_path: runtime/Dockerfile/RyzenAI-ONNX
-            image_name: aup-ryzenai-onnx-notebook
-            default_version: 'v2.0'
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -91,20 +181,193 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          context: ${{ matrix.docker_path }}
-          file: ${{ matrix.docker_path }}/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          images: ${{ needs.changes.outputs.registry }}/auplc-default
           tags: |
-            ghcr.io/amdresearch/${{ matrix.image_name }}:${{ github.event.inputs.override_versions || matrix.default_version }}
-            ghcr.io/amdresearch/${{ matrix.image_name }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Build and push Base CPU image
+        uses: docker/build-push-action@v6
+        with:
+          context: dockerfiles/Base
+          file: dockerfiles/Base/Dockerfile.cpu
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=base-cpu
+          cache-to: type=gha,mode=max,scope=base-cpu
+          provenance: false
+
+  # ──────────────────────────────────────────────
+  # Base GPU Image (gfx1151)
+  #
+  # No GPU hardware required — only downloads ROCm tarball + pip wheels.
+  # Uses free-disk-space action to reclaim runner disk for the large image.
+  # ──────────────────────────────────────────────
+  build-base-gpu:
+    name: Build Base GPU Image (gfx1151)
+    needs: changes
+    if: |
+      needs.changes.outputs.is-tag == 'true' ||
+      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.base-gpu == 'true') ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.images == 'all' || github.event.inputs.images == 'base-gpu'))
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.out.outputs.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.changes.outputs.registry }}/base-gfx1151
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event.inputs.version != '' }}
+            type=sha,prefix=sha-
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Build and push Base GPU image
+        uses: docker/build-push-action@v6
+        with:
+          context: dockerfiles/Base
+          file: dockerfiles/Base/Dockerfile.gfx1151
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=base-gpu
+          cache-to: type=gha,mode=max,scope=base-gpu
+          provenance: false
+
+      - name: Export first image tag for downstream jobs
+        if: github.event_name != 'pull_request'
+        id: out
+        run: echo "image=$(echo '${{ steps.meta.outputs.tags }}' | head -1)" >> "$GITHUB_OUTPUT"
+
+  # ──────────────────────────────────────────────
+  # Course Images (CV, DL, LLM, PhySim)
+  #
+  # These images use `FROM ghcr.io/amdresearch/base-gfx1151:v0.1-full`
+  # which is pre-built and pushed to GHCR. The build itself only copies
+  # files and installs pip packages — no GPU required.
+  #
+  # BASE_IMAGE build-arg overrides the default so course images
+  # can track the latest GPU base image version from CI.
+  # ──────────────────────────────────────────────
+  build-courses:
+    name: "Build Course: ${{ matrix.course }}"
+    needs: [changes, build-base-gpu]
+    if: |
+      always() &&
+      needs.changes.result == 'success' &&
+      (needs.build-base-gpu.result == 'success' || needs.build-base-gpu.result == 'skipped') &&
+      (
+        needs.changes.outputs.is-tag == 'true' ||
+        (github.event_name != 'workflow_dispatch' && needs.changes.outputs.courses == 'true') ||
+        (github.event_name == 'workflow_dispatch' && (github.event.inputs.images == 'all' || github.event.inputs.images == 'courses' || github.event.inputs.images == 'base-gpu'))
+      )
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - course: CV
+            image_suffix: auplc-cv
+            prepare: cp -r projects/CV dockerfiles/Courses/CV/course_data
+          - course: DL
+            image_suffix: auplc-dl
+            prepare: cp -r projects/DL dockerfiles/Courses/DL/course_data
+          - course: LLM
+            image_suffix: auplc-llm
+            prepare: cp -r projects/LLM dockerfiles/Courses/LLM/LLM
+          - course: PhySim
+            image_suffix: auplc-physim
+            prepare: cp -r projects/PhySim dockerfiles/Courses/PhySim/course_data
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare build context
+        run: ${{ matrix.prepare }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.changes.outputs.registry }}/${{ matrix.image_suffix }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event.inputs.version != '' }}
+            type=sha,prefix=sha-
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Build and push ${{ matrix.course }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: dockerfiles/Courses/${{ matrix.course }}
+          file: dockerfiles/Courses/${{ matrix.course }}/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ${{ needs.build-base-gpu.outputs.image && format('BASE_IMAGE={0}', needs.build-base-gpu.outputs.image) || '' }}
+          cache-from: type=gha,scope=course-${{ matrix.course }}
+          cache-to: type=gha,mode=max,scope=course-${{ matrix.course }}
+          provenance: false

--- a/dockerfiles/Base/Dockerfile.gfx1151
+++ b/dockerfiles/Base/Dockerfile.gfx1151
@@ -5,10 +5,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,60 +23,64 @@ FROM ${BASE_IMAGE}
 # Default Shell
 SHELL ["/bin/bash", "-c"]
 
-# Register the ROCM package repository, and install rocm-dev package
 # Create jovyan user with specific UID 1000
 ARG NB_USER=jovyan
 ARG NB_UID=1000
 ARG NB_GID=100
-ARG ROCM_VERSION=7.10.0
-ARG AMDGPU_VERSION=7.10.0
+
+# ROCm / PyTorch version pins — override at build time to upgrade
+# gfx110X-all covers gfx1100/1101/1102/1103; strix-halo (gfx1151) uses HSA_OVERRIDE
+ARG ROCM_VERSION=7.11.0
+ARG ROCM_TARBALL_URL=https://repo.amd.com/rocm/tarball/therock-dist-linux-gfx110X-all-${ROCM_VERSION}.tar.gz
+ARG PYTORCH_INDEX_URL=https://repo.amd.com/rocm/whl/gfx110X-all/
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV ROCM_PATH=/opt/rocm
 ENV PATH="${ROCM_PATH}/bin:${PATH}"
-ENV LD_LIBRARY_PATH="${ROCM_PATH}/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="${ROCM_PATH}/lib"
 ENV DEVICE_LIB_PATH=/opt/rocm/lib/llvm/amdgcn/bitcode
 ENV HIP_DEVICE_LIB_PATH=/opt/rocm/lib/llvm/amdgcn/bitcode
 
-# Override PIP configuration to allow system-wide installation
-RUN touch /etc/pip.conf && \
-    echo "[global]" > /etc/pip.conf && \
-    echo "break-system-packages = true" >> /etc/pip.conf
+# Allow pip to install system-wide
+RUN printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
 
-# Install system dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl libnuma-dev gnupg \
-  && curl -sL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - \
-  && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+# Install system dependencies (deduplicated)
+RUN apt-get update && apt-get install -y --no-install-recommends \
   sudo \
+  ca-certificates \
+  curl \
+  wget \
+  git \
+  gnupg \
+  build-essential \
+  python3-dev \
+  python3-pip \
+  libnuma-dev \
   libelf1 \
   kmod \
   file \
-  python3-dev \
-  python3-pip \
-  wget \
-  git \
-  build-essential \
-  ca-certificates \
-  git \
   locales \
   fonts-liberation \
-  run-one && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+  run-one \
+  && curl -sL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
-# Install ROCm 7.10.0
+# Install ROCm from tarball
 RUN mkdir -p /opt/rocm && \
-    wget https://repo.amd.com/rocm/tarball/therock-dist-linux-gfx1151-7.10.0.tar.gz && \
-    tar -xf therock-dist-linux-gfx1151-7.10.0.tar.gz -C /opt/rocm --strip-components=1 && \
-    rm therock-dist-linux-gfx1151-7.10.0.tar.gz
+    wget -q "${ROCM_TARBALL_URL}" -O /tmp/rocm.tar.gz && \
+    tar -xf /tmp/rocm.tar.gz -C /opt/rocm --strip-components=1 && \
+    rm /tmp/rocm.tar.gz
 
 # Install ROCm PyTorch
-RUN python3 -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ torch torchvision torchaudio --break-system-packages
+RUN python3 -m pip install --no-cache-dir \
+    --index-url "${PYTORCH_INDEX_URL}" \
+    torch torchvision torchaudio
 
-# Install JupyterHub and related packages system-wide
-RUN pip3 install --no-cache-dir --break-system-packages \
+# Install JupyterHub and related packages
+RUN pip3 install --no-cache-dir \
     jupyterhub==4.0.2 \
     jupyterlab==4.0.9 \
     notebook==7.0.6 \
@@ -88,7 +92,6 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     scikit-learn \
     numpy \
     pandas \
-    ipywidgets \
     hiredis \
     pillow \
     tqdm \

--- a/dockerfiles/Courses/CV/Dockerfile
+++ b/dockerfiles/Courses/CV/Dockerfile
@@ -18,7 +18,8 @@
 # SOFTWARE.
 
 # Use a verified ROCm PyTorch image as base
-FROM ghcr.io/amdresearch/base-gfx1151:v0.1-full
+ARG BASE_IMAGE=ghcr.io/amdresearch/base-gfx1151:v0.1-full
+FROM ${BASE_IMAGE}
 
 # Copy related rocm notebooks into the docker
 RUN mkdir -p /opt/workspace/CV

--- a/dockerfiles/Courses/CV/build.sh
+++ b/dockerfiles/Courses/CV/build.sh
@@ -5,10 +5,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,6 +20,7 @@
 
 cp -r ../../../projects/CV ./course_data
 
-docker build -t ghcr.io/amdresearch/auplc-cv:latest .
+docker build ${BASE_IMAGE:+--build-arg BASE_IMAGE="$BASE_IMAGE"} \
+  -t ghcr.io/amdresearch/auplc-cv:latest .
 
 rm -r course_data

--- a/dockerfiles/Courses/DL/Dockerfile
+++ b/dockerfiles/Courses/DL/Dockerfile
@@ -19,8 +19,8 @@
 
 
 # Use a verified ROCm PyTorch image as base
-#FROM harbor-aup-int.openhw.cloud:7443/rocm/therock_pytorch_dev_ubuntu_24_04_gfx1151:main
-FROM ghcr.io/amdresearch/base-gfx1151:v0.1-full
+ARG BASE_IMAGE=ghcr.io/amdresearch/base-gfx1151:v0.1-full
+FROM ${BASE_IMAGE}
 
 # Copy related rocm notebooks into the docker
 COPY ./course_data /opt/workspace/DL

--- a/dockerfiles/Courses/DL/build.sh
+++ b/dockerfiles/Courses/DL/build.sh
@@ -18,51 +18,9 @@
 # SOFTWARE.
 
 
-# #!/usr/bin/env bash
-# set -euo pipefail
-
-# # ===== FashionMNIST data check =====
-# DATA_DIR="./data/FashionMNIST/raw"
-
-# REQUIRED_FILES=(
-#   "train-images-idx3-ubyte"
-#   "train-labels-idx1-ubyte"
-#   "t10k-images-idx3-ubyte"
-#   "t10k-labels-idx1-ubyte"
-# )
-
-# echo "[INFO] Checking FashionMNIST dataset..."
-
-# if [[ ! -d "${DATA_DIR}" ]]; then
-#   echo "[WARRNING] ${DATA_DIR} does not exist."
-#   echo "Run:"
-#   cd data/FashionMNIST && bash ./download_data.sh
-#   cd ../../
-# fi
-
-# MISSING=false
-# for file in "${REQUIRED_FILES[@]}"; do
-#   if [[ ! -f "${DATA_DIR}/${file}" ]]; then
-#     echo "[MISSING] ${DATA_DIR}/${file}"
-#     MISSING=true
-#   fi
-# done
-
-# if [[ "${MISSING}" == true ]]; then
-#   echo
-#   echo "[ERROR] FashionMNIST dataset is incomplete."
-#   echo "Please download it first:"
-#   echo "  cd data/FashionMNIST && ./download_data.sh"
-#   exit 1
-# fi
-
-# ls -al
-
-# echo "[OK] FashionMNIST dataset found."
-
 cp -r ../../../projects/DL ./course_data
 
-docker build -t ghcr.io/amdresearch/auplc-dl:latest .
+docker build ${BASE_IMAGE:+--build-arg BASE_IMAGE="$BASE_IMAGE"} \
+  -t ghcr.io/amdresearch/auplc-dl:latest .
 
 rm -rf ./course_data
-

--- a/dockerfiles/Courses/LLM/Dockerfile
+++ b/dockerfiles/Courses/LLM/Dockerfile
@@ -18,7 +18,8 @@
 # SOFTWARE.
 
 # Use a verified ROCm PyTorch image as base
-FROM ghcr.io/amdresearch/base-gfx1151:v0.1-full
+ARG BASE_IMAGE=ghcr.io/amdresearch/base-gfx1151:v0.1-full
+FROM ${BASE_IMAGE}
 
 # Install JupyterHub and related packages system-wide
 RUN pip3 install --no-cache-dir --break-system-packages \

--- a/dockerfiles/Courses/LLM/build.sh
+++ b/dockerfiles/Courses/LLM/build.sh
@@ -5,10 +5,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,6 +19,7 @@
 
 cp -r ../../../projects/LLM ./LLM
 
-docker build -t ghcr.io/amdresearch/auplc-llm:latest .
+docker build ${BASE_IMAGE:+--build-arg BASE_IMAGE="$BASE_IMAGE"} \
+  -t ghcr.io/amdresearch/auplc-llm:latest .
 
 rm -r ./LLM/

--- a/dockerfiles/Courses/PhySim/Dockerfile
+++ b/dockerfiles/Courses/PhySim/Dockerfile
@@ -18,7 +18,8 @@
 # SOFTWARE.
 
 # Use a verified ROCm PyTorch image as base
-FROM ghcr.io/amdresearch/base-gfx1151:v0.1-full
+ARG BASE_IMAGE=ghcr.io/amdresearch/base-gfx1151:v0.1-full
+FROM ${BASE_IMAGE}
 
 USER root
 # Vulkan backend and GUI

--- a/dockerfiles/Courses/PhySim/build.sh
+++ b/dockerfiles/Courses/PhySim/build.sh
@@ -20,6 +20,7 @@
 
 cp -r ../../../projects/PhySim ./course_data
 
-docker build -t ghcr.io/amdresearch/auplc-physim:latest .
+docker build ${BASE_IMAGE:+--build-arg BASE_IMAGE="$BASE_IMAGE"} \
+  -t ghcr.io/amdresearch/auplc-physim:latest .
 
 rm -r course_data

--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -13,6 +13,9 @@ MIRROR_PREFIX ?=
 MIRROR_PIP ?=
 MIRROR_NPM ?=
 
+# GPU base image used by course Dockerfiles (override to track a specific version)
+GPU_BASE_IMAGE ?= ghcr.io/amdresearch/base-gfx1151:v0.1-full
+
 # Build args for docker build (constructed from mirror settings)
 BUILD_ARGS :=
 ifneq ($(MIRROR_PREFIX),)
@@ -74,7 +77,7 @@ cv:
 		echo "Building CV Course Image..."; \
 		echo "-------------------------------------------";
 
-	cd Courses/CV && bash ./build.sh
+	cd Courses/CV && BASE_IMAGE=$(GPU_BASE_IMAGE) bash ./build.sh
 	$(MAKE) save-image IMAGE=ghcr.io/amdresearch/auplc-cv:latest
 
 dl:
@@ -82,7 +85,7 @@ dl:
 		echo "Building DL Course Image..."; \
 		echo "-------------------------------------------";
 
-	cd Courses/DL && bash ./build.sh
+	cd Courses/DL && BASE_IMAGE=$(GPU_BASE_IMAGE) bash ./build.sh
 	$(MAKE) save-image IMAGE=ghcr.io/amdresearch/auplc-dl:latest
 
 llm:
@@ -90,7 +93,7 @@ llm:
 		echo "Building LLM Course Image..."; \
 		echo "-------------------------------------------";
 
-	cd Courses/LLM && bash ./build.sh
+	cd Courses/LLM && BASE_IMAGE=$(GPU_BASE_IMAGE) bash ./build.sh
 	$(MAKE) save-image IMAGE=ghcr.io/amdresearch/auplc-llm:latest
 
 physim:
@@ -98,7 +101,7 @@ physim:
 		echo "Building PhySim Course Image..."; \
 		echo "-------------------------------------------";
 
-	cd Courses/PhySim && bash ./build.sh
+	cd Courses/PhySim && BASE_IMAGE=$(GPU_BASE_IMAGE) bash ./build.sh
 	$(MAKE) save-image IMAGE=ghcr.io/amdresearch/auplc-physim:latest
 
 # --- Export Images ---


### PR DESCRIPTION
## Summary
- Enable GPU base image (`base-gfx1151`) builds on GitHub Actions without GPU hardware or self-hosted runners
- The build only downloads a ROCm tarball and installs pre-compiled PyTorch wheels — pure I/O, no GPU needed
- Use `jlumbroso/free-disk-space` to reclaim runner disk for the large image
- Use `gfx110X-all` ROCm tarball and PyTorch wheels for broad GPU arch coverage (gfx1100/1101/1102/1103); strix-halo (gfx1151) uses HSA_OVERRIDE_GFX_VERSION=11.0.0
- Parameterize `BASE_IMAGE` in course Dockerfiles so they automatically track the GPU base version from CI
- Sync Makefile and build.sh scripts to support `BASE_IMAGE` pass-through

## Changes
- **`dockerfiles/Base/Dockerfile.gfx1151`**: Use gfx110X-all tarball and wheel index, parameterize ROCm/PyTorch versions via ARGs, deduplicate dependencies, simplify pip.conf
- **`dockerfiles/Courses/*/Dockerfile`**: Add `ARG BASE_IMAGE` with backward-compatible default
- **`.github/workflows/docker-build.yml`**:
  - Add `build-base-gpu` job on `ubuntu-latest` with disk cleanup
  - Course jobs depend on GPU base completion before building
  - Add `base-gpu` to `workflow_dispatch` options
  - Unified tag strategy via metadata-action
- **`dockerfiles/Makefile`** + **`build.sh`**: Pass `GPU_BASE_IMAGE` / `BASE_IMAGE` build-arg

## Test Results
- Full build on fork passed (8/8 jobs success)
- With GHA cache: GPU base build drops from ~20min to ~3min
- Verified on real GPU hardware with HSA_OVERRIDE=11.0.0 on strix-halo
- Image size: 4.31 GB compressed, covers gfx1100-1103 natively

## Test plan
- [x] Full `workflow_dispatch` build on fork
- [x] GPU base image cache acceleration verified
- [x] Real GPU validation with CI-built image (strix-halo + HSA_OVERRIDE)
- [x] Multi-arch gfx110X-all coverage verified
- [ ] Post-merge tag push build on main repo