### PR TITLE
fix(installer): clean up Docker containers left by k3s on uninstall

### DIFF
--- a/auplc-installer
+++ b/auplc-installer
@@ -419,18 +419,21 @@ function remove_k3s_docker_containers() {
         return 0
     fi
 
+    # Filter by the Kubernetes-specific label that kubelet stamps on every
+    # container it creates via dockershim/cri-dockerd.  This is more precise
+    # than matching the "k8s_" name prefix, which could accidentally catch
+    # user containers with similar names.
     local k8s_containers
-    k8s_containers=$(docker ps -a -q --filter "name=k8s_" 2>/dev/null || true)
+    k8s_containers=$(docker ps -a -q --filter "label=io.kubernetes.pod.name" 2>/dev/null || true)
     if [[ -z "$k8s_containers" ]]; then
         return 0
     fi
 
     echo ""
-    echo "The following Docker containers with the 'k8s_' prefix were found."
-    echo "These are typically Pod containers left behind by k3s (Docker runtime mode),"
-    echo "but may also include containers from other Kubernetes environments (e.g. minikube)."
+    echo "The following Docker containers managed by Kubernetes were found."
+    echo "These are Pod containers left behind by k3s (Docker runtime mode)."
     echo ""
-    docker ps -a --filter "name=k8s_" --format "  {{.ID}}  {{.Names}}"
+    docker ps -a --filter "label=io.kubernetes.pod.name" --format "  {{.ID}}  {{.Names}}"
     echo ""
 
     local confirm
@@ -440,7 +443,7 @@ function remove_k3s_docker_containers() {
     elif [[ ! -t 0 ]]; then
         echo "Non-interactive environment detected. Skipping Docker container cleanup."
         echo "To remove them manually, run:"
-        echo "  docker rm -f \$(docker ps -a -q --filter 'name=k8s_')"
+        echo "  docker rm -f \$(docker ps -a -q --filter 'label=io.kubernetes.pod.name')"
         return 0
     else
         read -r -p "Remove all of the above containers? [y/N] " confirm
@@ -448,7 +451,7 @@ function remove_k3s_docker_containers() {
 
     if [[ "${confirm,,}" != "y" ]]; then
         echo "Skipping Docker container cleanup. You can remove them manually with:"
-        echo "  docker rm -f \$(docker ps -a -q --filter 'name=k8s_')"
+        echo "  docker rm -f \$(docker ps -a -q --filter 'label=io.kubernetes.pod.name')"
         return 0
     fi
 


### PR DESCRIPTION
## Problem

When k3s is installed with `--docker`, all Pod containers are managed by Docker and appear in `docker ps` with a `k8s_` prefix. The k3s uninstall script (`k3s-uninstall.sh`) only handles its embedded containerd runtime and makes no Docker API calls, so these containers are silently left behind after uninstall.

This is a known upstream issue: [k3s-io/k3s#1469](https://github.com/k3s-io/k3s/issues/1469).

Closes #45

## Changes

Add `remove_k3s_docker_containers()` to the `remove_k3s` flow. After `k3s-uninstall.sh` runs, it:

- Detects leftover containers using `--filter "label=io.kubernetes.pod.name"` (the label kubelet stamps on every container it creates via dockershim/cri-dockerd), which is more precise than matching the `k8s_` name prefix
- Lists the containers and prompts for confirmation before removing
- In non-interactive environments (stdin is not a TTY): skips automatically and prints the manual cleanup command
- With `--yes` / `AUPLC_YES=1`: removes without prompting, for scripted/CI use

## Testing

- [ ] Run `./auplc-installer uninstall` with containers present, confirm prompt lists containers correctly
- [ ] Answer N, confirm containers are not removed
- [ ] Answer Y, confirm containers are stopped and removed
- [ ] Run via pipe (`echo y | ./auplc-installer uninstall`), confirm non-interactive path triggers
- [ ] Run with `--yes`, confirm auto-removal without prompt