### PR TITLE
fix(installer): remove dummy0 default route that breaks internet conn…

### DIFF
--- a/auplc-installer
+++ b/auplc-installer
@@ -342,7 +342,6 @@ function setup_dummy_interface() {
     sudo ip link add dummy0 type dummy
     sudo ip link set dummy0 up
     sudo ip addr add "${K3S_NODE_IP}/32" dev dummy0
-    sudo ip route add default via "${K3S_NODE_IP}" dev dummy0 metric 1000 2>/dev/null || true
 
     cat << EOF | sudo tee /etc/systemd/system/dummy-interface.service > /dev/null
 [Unit]
@@ -353,7 +352,7 @@ After=network.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/bash -c 'ip link show dummy0 || (ip link add dummy0 type dummy && ip link set dummy0 up && ip addr add ${K3S_NODE_IP}/32 dev dummy0 && ip route add default via ${K3S_NODE_IP} dev dummy0 metric 1000 2>/dev/null || true)'
+ExecStart=/bin/bash -c 'ip link show dummy0 || (ip link add dummy0 type dummy && ip link set dummy0 up && ip addr add ${K3S_NODE_IP}/32 dev dummy0)'
 ExecStop=/bin/bash -c 'ip link del dummy0 2>/dev/null || true'
 
 [Install]


### PR DESCRIPTION
…ectivity

The dummy0 interface adds a default route with metric 1000, which takes priority over the real network interface (e.g. WiFi at metric 20600), causing all traffic to route through a virtual interface with no actual connectivity. Remove the unnecessary default route from both the install step and the systemd service — dummy0 only needs to provide a stable IP for K3s node binding.

Made-with: Cursor

## Summary

## Changes

## Testing

## Files Changed

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Tested on local Kubernetes cluster
- [x] Documentation links updated
