### PR TITLE
Fix ROCm device permissions for multi-user GPU access

### DIFF
--- a/deploy/ansible/roles/rocm/tasks/main.yml
+++ b/deploy/ansible/roles/rocm/tasks/main.yml
@@ -53,3 +53,24 @@
   apt:
     name: rocm
     state: present
+
+- name: Ensure render group exists with consistent GID
+  group:
+    name: render
+    gid: 993
+    state: present
+
+- name: Set udev rules for ROCm devices with correct permissions
+  copy:
+    content: |
+      # ROCm device permissions
+      # Ensure /dev/kfd and /dev/dri/renderD* are accessible by render group
+      SUBSYSTEM=="kfd", GROUP="render", MODE="0660"
+      SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="render", MODE="0660"
+    dest: /etc/udev/rules.d/70-rocm-devices.rules
+    mode: '0644'
+  notify: Reload udev rules
+
+- name: Reload udev rules
+  shell: udevadm control --reload-rules && udevadm trigger
+  changed_when: false

--- a/deploy/ansible/roles/rocm/tasks/main.yml
+++ b/deploy/ansible/roles/rocm/tasks/main.yml
@@ -64,13 +64,14 @@
   copy:
     content: |
       # ROCm device permissions
-      # Ensure /dev/kfd and /dev/dri/renderD* are accessible by render group
-      SUBSYSTEM=="kfd", GROUP="render", MODE="0660"
+      # Grant render group access to AMD GPU devices
+      # Reference: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/prerequisites.html#using-udev-rules
+      KERNEL=="kfd", GROUP="render", MODE="0660"
       SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="render", MODE="0660"
-    dest: /etc/udev/rules.d/70-rocm-devices.rules
+    dest: /etc/udev/rules.d/70-amdgpu.rules
     mode: '0644'
-  notify: Reload udev rules
+  register: udev_rules_changed
 
-- name: Reload udev rules
+- name: Reload udev rules if changed
   shell: udevadm control --reload-rules && udevadm trigger
-  changed_when: false
+  when: udev_rules_changed.changed

--- a/runtime/values.yaml
+++ b/runtime/values.yaml
@@ -383,6 +383,15 @@ monitoring:
     enabled: false
 
 singleuser:
+  # Security context for user pods to access GPU devices
+  # supplementalGroups grants container access to host's render group (GID 993)
+  # This allows non-root users to access /dev/kfd and /dev/dri devices
+  extraPodConfig:
+    securityContext:
+      fsGroup: 100
+      supplementalGroups:
+        - 993  # render group for ROCm GPU access
+  
   storage:
     dynamic:
       storageClass: local-path

--- a/runtime/values.yaml
+++ b/runtime/values.yaml
@@ -391,7 +391,7 @@ singleuser:
       fsGroup: 100
       supplementalGroups:
         - 993  # render group for ROCm GPU access
-  
+
   storage:
     dynamic:
       storageClass: local-path


### PR DESCRIPTION
## Summary

Fixes permission denied errors when JupyterHub notebook containers attempt to access ROCm GPU devices (`/dev/kfd` and `/dev/dri/renderD*`).

## Problem

Multi-user JupyterHub deployments encountered "permission denied" errors when notebooks tried to access GPU devices:
- Device files mounted by AMD GPU device plugin but inaccessible
- Container user (uid 1000) not in render group (gid 993)
- Affects multi-node clusters with manual Helm deployment (auplc-installer already handled this)

## Solution

**Dual approach for robustness:**

1. **Ansible (host-level)**:
   - Ensure `render` group exists with consistent GID 993 across all nodes
   - Add udev rules following [ROCm official documentation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/prerequisites.html#using-udev-rules)
   - Use `KERNEL=="kfd"` (not `SUBSYSTEM=="kfd"`) per official spec
   - File named `70-amdgpu.rules` for consistency with AMD conventions
   - Guarantees persistent permissions after reboots

2. **Helm values (container-level)**:
   - Configure `supplementalGroups: [993]` in Pod securityContext
   - Grants container users access to render group
   - Standard Kubernetes security practice

## Benefits

- ✅ Follows ROCm official documentation standards
- ✅ Works on heterogeneous clusters (different Ubuntu versions)
- ✅ Secure (0660 instead of world-writable 0666)
- ✅ Persistent across reboots
- ✅ No impact on CPU-only nodes
- ✅ Automatic for new GPU nodes

## Testing

- ✅ Helm chart lint passes
- ✅ Schema validation passes
- ✅ Config tested on NV20 deployment
- ✅ Aligned with AMD official udev rules format

## References

- ROCm k8s-device-plugin issue #39: https://github.com/ROCm/k8s-device-plugin/issues/39
- ROCm k8s-device-plugin issue #65: https://github.com/ROCm/k8s-device-plugin/issues/65
- ROCm Prerequisites - Using udev rules: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/prerequisites.html#using-udev-rules
- Kubernetes supplementalGroups docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#podsecuritycontext-v1-core