### PR TITLE
Add default group for GitHub users without team assignments

### DIFF
--- a/runtime/hub/core/setup.py
+++ b/runtime/hub/core/setup.py
@@ -102,7 +102,7 @@ def setup_hub(c: Any) -> None:
     # Ensure system-managed groups exist at startup (before any user logs in).
     # Note: load_groups does NOT set properties on existing groups, so the
     # source=system backfill is handled lazily in the admin groups API handler.
-    c.JupyterHub.load_groups = {"native-users": []}
+    c.JupyterHub.load_groups = {"native-users": [], "github-users": []}
 
     # =========================================================================
     # Configure Authenticator
@@ -149,6 +149,14 @@ def setup_hub(c: Any) -> None:
                     await spawner.user.save_auth_state(auth_state)
                 except Exception as e:
                     print(f"[GROUPS] Warning: Failed to sync GitHub teams for {spawner.user.name}: {e}")
+
+            # Assign all GitHub users to default group (fallback for users without teams)
+            try:
+                from core.groups import assign_user_to_group
+
+                assign_user_to_group(spawner.user, "github-users", spawner.user.db)
+            except Exception as e:
+                print(f"[GROUPS] Warning: Failed to assign github-users group for {spawner.user.name}: {e}")
         elif not spawner.user.name.startswith("github:"):
             # Native user with auth_state but no GitHub teams
             try:

--- a/runtime/values.yaml
+++ b/runtime/values.yaml
@@ -294,6 +294,13 @@ custom:
         - Course-PhySim
         - cpu
         - gpu
+      github-users:
+        - cpu
+        - gpu
+        - Course-CV
+        - Course-DL
+        - Course-LLM
+        - Course-PhySim
 
   # ============================================================================
   # Quota Management


### PR DESCRIPTION
## Summary

Ensures all GitHub users have access to default resources even when they are not members of any GitHub team in the organization.

## Problem

GitHub OAuth users who are not assigned to any team in the organization receive no resources:
- `get_user_resources()` returns `["none"]` when no groups match
- The "none" resource has 0 CPU and 0 memory, making it unusable
- Users see an empty or broken spawn form, unable to start any notebooks
- Inconsistent with native users who automatically get the `native-users` group

## Solution

**Auto-assign GitHub users to default group:**

1. **Code changes (`runtime/hub/core/setup.py`)**:
   - All GitHub users are automatically assigned to `github-users` system group during spawn
   - Pre-create `github-users` group at hub startup (similar to `native-users`)
   - Follows the same pattern as native user group assignment

2. **Configuration changes (`runtime/values.yaml`)**:
   - Add `github-users` to team resource mapping with default access:
     - cpu
     - gpu
     - Course-CV
     - Course-DL
     - Course-LLM
     - Course-PhySim

## Benefits

- ✅ GitHub users always have access to base resources
- ✅ Team membership grants additional resources via group merging
- ✅ Consistent behavior with native users
- ✅ No breaking changes to existing team permissions
- ✅ Users can start notebooks immediately after first login

## Testing

- [ ] Verify GitHub user without team can spawn notebooks
- [ ] Verify GitHub user with team gets both team + default resources
- [ ] Verify group appears in admin panel as system-managed
- [ ] Verify native users still work as before