### PR TITLE
fix: resolve Strix GPUs to native gfx1150 target

### DIFF
--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -1,6 +1,7 @@
 {
   "gpu_targets": [
     {"name": "gfx110x", "pytorch_whl": "gfx110X-all"},
+    {"name": "gfx1150", "pytorch_whl": "gfx1150"},
     {"name": "gfx1151", "pytorch_whl": "gfx1151"},
     {"name": "gfx120x", "pytorch_whl": "gfx120X-all"}
   ],

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -62,7 +62,9 @@ on:
         options:
           - all
           - gfx110x
+          - gfx1150
           - gfx1151
+          - gfx120x
 
 # Build matrix is defined in .github/build-config.json
 

--- a/.github/workflows/pack-bundle.yml
+++ b/.github/workflows/pack-bundle.yml
@@ -37,7 +37,7 @@ on:
         options:
           - strix-halo   # gfx1151 — Ryzen AI Max+ 395 / Max 390
           - phx          # gfx110x — Ryzen AI 300 (Phoenix)
-          - strix        # gfx110x + HSA override — Ryzen AI 300 (Strix Point)
+          - strix        # gfx1150 — Ryzen AI 300 (Strix Point)
           - rdna4        # gfx120x — Radeon RX 9000 series
       image_tag:
         description: 'Image tag prefix (default: current branch/tag name)'

--- a/auplc-installer
+++ b/auplc-installer
@@ -176,8 +176,8 @@ function resolve_gpu_config() {
             ;;
         gfx1150|strix)
             ACCEL_KEY="strix"
-            GPU_TARGET="gfx110x"
-            ACCEL_ENV="11.0.0"
+            GPU_TARGET="gfx1150"
+            ACCEL_ENV=""
             ;;
         gfx1151|strix-halo)
             ACCEL_KEY="strix-halo"

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -43,8 +43,10 @@ ARG ROCM_VERSION=7.11.0
 ARG PYTORCH_VERSION=2.9.1
 ARG TORCHVISION_VERSION=0.24.0
 ARG TORCHAUDIO_VERSION=2.9.0
-# PyTorch wheel target — may differ from GPU_TARGET (e.g. gfx110x → gfx110X-all)
-# See https://repo.amd.com/rocm/whl/ for available targets
+# PyTorch wheel target — only differs from GPU_TARGET for the generic
+# buckets (gfx110x → gfx110X-all, gfx120x → gfx120X-all). Specific targets
+# like gfx1150/gfx1151/gfx1152 use the same name in both apt and wheel repos.
+# See https://repo.amd.com/rocm/whl/ for available targets.
 ARG PYTORCH_WHL_TARGET=
 ARG PYTORCH_INDEX_URL=
 

--- a/runtime/values.yaml
+++ b/runtime/values.yaml
@@ -134,6 +134,10 @@ custom:
       nodeSelector:
         node-type: phx
       env:
+        # Phoenix hw (gfx1100/1101/1102/1103) shares a single gfx110x ROCm
+        # build — we do not ship dedicated images for gfx1102/gfx1103 — so
+        # force every Phoenix GPU to report as gfx1100 at runtime so it
+        # accepts the shared kernels.
         HSA_OVERRIDE_GFX_VERSION: "11.0.0"
       quotaRate: 2
     strix:


### PR DESCRIPTION
## Summary

- `auplc-installer` resolved Strix (Radeon 890M, RDNA 3.5) to the generic `gfx110x` target with `HSA_OVERRIDE_GFX_VERSION=11.0.0`, forcing the GPU to masquerade as `gfx1100`. `gfx1150` is now a first-class target in both the ROCm apt repo and the PyTorch wheel repo, so use it directly and drop the HSA override. This also fixes `make base-rocm` on Strix, which was failing at the torch install step because it does not pass `PYTORCH_WHL_TARGET` and the wheel URL resolved to the non-existent `https://repo.amd.com/rocm/whl/gfx110x/` directory.
- CI build matrix (`.github/build-config.json`) gains a `gfx1150` entry so `auplc-base:*-gfx1150` is published to GHCR. Without it `auplc-installer img pull` and the `strix` pack-bundle job would find nothing.
- Stale comments in `pack-bundle.yml` and `Dockerfile.rocm`, plus the missing `gfx1150`/`gfx120x` options in the `docker-build.yml` `workflow_dispatch` choice list, are cleaned up.
- The HSA override on the `phx` accelerator in `runtime/values.yaml` stays — Phoenix hw still shares one `gfx110x` ROCm build across gfx1100/1101/1102/1103 — but is now documented so readers understand why Strix loses the override while `phx` keeps it.

## Changes

| File | Change |
|---|---|
| `auplc-installer` | `strix` case: `GPU_TARGET=gfx110x` → `gfx1150`, clear `ACCEL_ENV` |
| `.github/build-config.json` | Add `{"name": "gfx1150", "pytorch_whl": "gfx1150"}` |
| `.github/workflows/docker-build.yml` | Add `gfx1150` and `gfx120x` to `workflow_dispatch` `gpu_target` choices |
| `.github/workflows/pack-bundle.yml` | Update `strix` comment: `# gfx1150` (was `# gfx110x + HSA override`) |
| `dockerfiles/Base/Dockerfile.rocm` | Clarify `PYTORCH_WHL_TARGET` comment: mapping only needed for generic `gfx110x`/`gfx120x` buckets |
| `runtime/values.yaml` | Document why `phx` accelerator keeps `HSA_OVERRIDE_GFX_VERSION=11.0.0` |

## Test plan

- [x] On a Strix machine (gfx1150), run `./auplc-installer img build` and confirm:
  - ROCm apt package `amdrocm7.11-gfx1150` installs (verified available at `https://repo.amd.com/rocm/packages/ubuntu2404/`)
  - `torch` installs from `https://repo.amd.com/rocm/whl/gfx1150/` (verified directory exists)
  - Built `auplc-base` image tags with `-gfx1150` suffix
- [x] Run the `Build Docker Images` workflow with `gpu_target=gfx1150` via `workflow_dispatch` and confirm the base-gpu matrix job succeeds and pushes `auplc-base:*-gfx1150` to GHCR
- [x] Run the `Pack Offline Bundle` workflow with `gpu_type=strix` and confirm it pulls the new `gfx1150` image and produces a bundle
- [x] Sanity-check that `phx` (still `gfx110x` + `gfx110X-all` + HSA override) and `strix-halo` (still `gfx1151`) paths are untouched
