### PR TITLE
feat(base): add unzip to ROCm base image

### DIFF
--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -79,6 +79,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   fonts-liberation \
   run-one \
   libatomic1 \
+  unzip \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Install the `unzip` apt package in the ROCm base image so container workloads can extract zip archives without running `apt-get install unzip` at runtime.

## Changes

| File | Change |
|---|---|
| `dockerfiles/Base/Dockerfile.rocm` | Add `unzip` to the `apt-get install` list in the system dependencies step |

## Test plan

- [ ] `make base-rocm` (or `./auplc-installer img build`) completes with the extra package
- [ ] `docker run --rm <built-image> unzip -v` prints the unzip version

Made with [Cursor](https://cursor.com)