### PR TITLE
feat(base): bump JupyterLab to 4.5.6 and notebook to 7.5.5

### DIFF
--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -124,8 +124,8 @@ RUN WHL_TARGET="${PYTORCH_WHL_TARGET:-${GPU_TARGET}}" && \
 # Install JupyterHub and related packages
 RUN pip3 install --no-cache-dir \
     jupyterhub==4.0.2 \
-    jupyterlab==4.0.9 \
-    notebook==7.0.6 \
+    jupyterlab==4.5.6 \
+    notebook==7.5.5 \
     ipywidgets==8.1.1 \
     ipykernel==6.27.1 \
     matplotlib \


### PR DESCRIPTION
## Summary

Pull the ROCm base image's JupyterLab / notebook stack forward to the current stable releases.

| Package | Old | New |
|---|---|---|
| `jupyterlab` | 4.0.9 | **4.5.6** |
| `notebook` | 7.0.6 | **7.5.5** |

Other pinned packages in the same `pip install` block (`jupyterhub==4.0.2`, `ipywidgets==8.1.1`, `ipykernel==6.27.1`, `jupyterlab-server-timer`) are intentionally left alone to avoid drifting away from the Hub image's pinned versions and to keep the compatibility surface small in this PR.

## Compatibility notes

- Notebook 7.5 is built on JupyterLab 4.5, so the two versions are in lockstep.
- Notebook 7.5 still supports extensions written against JupyterLab 4.0, so `jupyterlab-server-timer` 0.1.3 (classified as `Jupyter :: JupyterLab :: 4`) keeps working.
- `jupyterhub==4.0.2` (singleuser side) remains compatible with the Hub image's `k8s-hub:4.1.0`, so we don't touch it here.

## Test plan

- [ ] `make base-rocm` (or `./auplc-installer img build`) produces an image where:
  - `pip show jupyterlab` reports `4.5.6`
  - `pip show notebook` reports `7.5.5`
- [ ] A spawned singleuser container starts JupyterLab without extension load errors
- [ ] `jupyter-server-timer` extension still shows the remaining time indicator in the status bar
- [ ] Course images built from this base (CV / DL / LLM / PhySim) still build and launch

Made with [Cursor](https://cursor.com)