### PR TITLE
fix(physim): upgrade genesis-world to 0.4.6

### DIFF
--- a/dockerfiles/Courses/PhySim/Dockerfile
+++ b/dockerfiles/Courses/PhySim/Dockerfile
@@ -45,7 +45,7 @@ RUN pip3 install --no-cache-dir \
     loguru \
     omegaconf \
     gstaichi \
-    "genesis-world==0.4.3"
+    "genesis-world==0.4.6"
 
 # Copy related rocm notebooks into the docker
 RUN mkdir -p /opt/workspace/PhySim


### PR DESCRIPTION
## Summary

Upgrades PhySim Docker image from `genesis-world==0.4.3` to `genesis-world==0.4.6` to resolve the AMD/ROCm compatibility regression introduced in v0.4.5.

## Context

Genesis v0.4.5 broke `scene.build()` on AMD/ROCm due to hardcoded `cuda.bindings.runtime` queries. We temporarily pinned to v0.4.3 as a workaround.

Genesis v0.4.6 (released 2026-04-11) now includes the fix from upstream PR #2664.

## Changes

- `dockerfiles/Courses/PhySim/Dockerfile`: `genesis-world==0.4.3` → `genesis-world==0.4.6`

## Upstream References

- **Genesis v0.4.6 Release**: https://github.com/Genesis-Embodied-AI/Genesis/releases/tag/v0.4.6
- **Fix PR #2664**: https://github.com/Genesis-Embodied-AI/Genesis/pull/2664

### Key Fixes in v0.4.6

- ✅ Replaced `cuda.bindings.runtime` with cross-platform shared-memory query
- ✅ Enabled parallel linesearch on all GPU backends (not just CUDA)
- ✅ Fixed contact overflow causing unbounded memory access  
- ✅ Relaxed CUDA Toolkit requirements

## Testing Plan

**Required before merging**:

1. [ ] Build PhySim Docker image with genesis-world==0.4.6
2. [ ] Launch PhySim pod on AMD/ROCm hardware
3. [ ] Run PhySim Lab 1 and verify:
   - `gs.init(backend=gs.amdgpu, theme="light")` succeeds
   - `scene.build()` succeeds without errors
   - No `cuda-python` dependency required
   - No `TypeError: unsupported operand type(s) for /=` errors

## Related Issues

- Resolves: #60
- JIRA: AUPPM-21

---

**⚠️ Draft Status**: Awaiting testing verification on AMD/ROCm hardware before marking ready for review.