### PR TITLE
fix(hub): make Hub subpath paths runtime-safe

### DIFF
--- a/runtime/chart/templates/monitoring/hub-servicemonitor.yaml
+++ b/runtime/chart/templates/monitoring/hub-servicemonitor.yaml
@@ -15,6 +15,6 @@ spec:
       component: hub
   endpoints:
     - targetPort: 8081
-      path: /hub/metrics
+      path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/metrics
       interval: {{ .Values.monitoring.serviceMonitor.interval }}
 {{- end }}

--- a/runtime/hub/core/authenticators/jwt.py
+++ b/runtime/hub/core/authenticators/jwt.py
@@ -75,7 +75,7 @@ class RemoteLabAuthenticator(Authenticator):
         return payload["data"]
 
     custom_html = """
-    <form action="/hub/login"
+    <form action="{{ base_url }}login?next={{ next | urlencode }}"
                 method="post"
                 role="form">
             <div class="auth-form-header">

--- a/runtime/hub/frontend/apps/admin/vite.config.ts
+++ b/runtime/hub/frontend/apps/admin/vite.config.ts
@@ -24,7 +24,9 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig(({ command }) => ({
   plugins: [react(), tailwindcss()],
-  // Base path for JupyterHub static files
+  // Dev keeps Vite's default root-style asset paths.
+  // Build uses a relative base so follow-on chunks/assets resolve from the
+  // runtime script URL injected by JupyterHub templates via static_url(...).
   base: command === 'build' ? './' : '/',
   build: {
     outDir: 'dist',

--- a/runtime/hub/frontend/apps/admin/vite.config.ts
+++ b/runtime/hub/frontend/apps/admin/vite.config.ts
@@ -22,10 +22,10 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react(), tailwindcss()],
   // Base path for JupyterHub static files
-  base: '/hub/static/admin-ui/',
+  base: command === 'build' ? './' : '/',
   build: {
     outDir: 'dist',
     // Generate assets with consistent names for easier integration
@@ -37,4 +37,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))

--- a/runtime/hub/frontend/apps/home/vite.config.ts
+++ b/runtime/hub/frontend/apps/home/vite.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react()],
-  base: '/hub/static/home-ui/',
+  base: command === 'build' ? './' : '/',
   build: {
     outDir: 'dist',
     rollupOptions: {
@@ -14,4 +14,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))

--- a/runtime/hub/frontend/apps/home/vite.config.ts
+++ b/runtime/hub/frontend/apps/home/vite.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig(({ command }) => ({
   plugins: [react()],
+  // Dev keeps Vite's default root-style asset paths.
+  // Build uses a relative base so follow-on chunks/assets resolve from the
+  // runtime script URL injected by JupyterHub templates via static_url(...).
   base: command === 'build' ? './' : '/',
   build: {
     outDir: 'dist',

--- a/runtime/hub/frontend/apps/spawn/vite.config.ts
+++ b/runtime/hub/frontend/apps/spawn/vite.config.ts
@@ -22,6 +22,9 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig(({ command }) => ({
   plugins: [react()],
+  // Dev keeps Vite's default root-style asset paths.
+  // Build uses a relative base so follow-on chunks/assets resolve from the
+  // runtime script URL injected by JupyterHub templates via static_url(...).
   base: command === 'build' ? './' : '/',
   build: {
     outDir: 'dist',

--- a/runtime/hub/frontend/apps/spawn/vite.config.ts
+++ b/runtime/hub/frontend/apps/spawn/vite.config.ts
@@ -20,9 +20,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react()],
-  base: '/hub/static/spawn-ui/',
+  base: command === 'build' ? './' : '/',
   build: {
     outDir: 'dist',
     rollupOptions: {
@@ -33,4 +33,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))

--- a/runtime/hub/frontend/templates/login.html
+++ b/runtime/hub/frontend/templates/login.html
@@ -93,7 +93,7 @@ AUP Learning Cloud
             <div id="announcement-box" class="bg-blue-50 text-blue-900 border border-blue-200 p-4 mb-6 rounded-lg hidden"></div>
             
             <script>
-                fetch("/hub/static/announcement.txt")
+                fetch("{{ static_url('announcement.txt') }}")
                     .then(resp => {
                         if (!resp.ok) throw new Error("Not found");
                         return resp.text();

--- a/runtime/hub/frontend/templates/resource_options_form.html
+++ b/runtime/hub/frontend/templates/resource_options_form.html
@@ -18,8 +18,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <head>
-<link rel="stylesheet" href="/hub/static/spawn-ui/assets/index.css" />
+<link rel="stylesheet" href="{{ static_url('spawn-ui/assets/index.css') }}" />
 </head>
 
 <div id="spawn-root"></div>
-<script type="module" src="/hub/static/spawn-ui/assets/index.js"></script>
+<script type="module" src="{{ static_url('spawn-ui/assets/index.js') }}"></script>


### PR DESCRIPTION
## Summary

Make the Hub's runtime paths safe under subpath deployments such as `/rlc`.

This PR fixes three classes of subpath issues:
- template and static asset URLs that were hardcoded to `/hub/static/...`
- auth and monitoring paths that ignored `hub.baseUrl`
- Vite build output that used a compile-time absolute public base instead of resolving assets relative to the runtime entry URL

## Problem

The Hub already had partial `baseUrl` awareness, but several runtime paths still assumed root-hosted `/hub/...`.

This showed up in four places:
- login and spawn-related templates emitted hardcoded `/hub/static/...` asset requests
- the legacy JWT authenticator posted to `/hub/login`
- the ServiceMonitor scraped `/hub/metrics` directly instead of following `hub.baseUrl`
- the admin / home / spawn Vite builds used absolute `base` values like `/hub/static/admin-ui/`, which made built asset graphs tied to a compile-time path instead of the runtime path injected by Jinja templates

## Solution

1. **Template/runtime asset fixes**
   - `runtime/hub/frontend/templates/login.html`
   - `runtime/hub/frontend/templates/resource_options_form.html`
   - Replace hardcoded `/hub/static/...` references with `static_url(...)`

2. **Auth and monitoring path fixes**
   - `runtime/hub/core/authenticators/jwt.py`
   - `runtime/chart/templates/monitoring/hub-servicemonitor.yaml`
   - Make login and metrics paths honor `base_url` / `hub.baseUrl`

3. **Runtime-variable Vite build base**
   - `runtime/hub/frontend/apps/admin/vite.config.ts`
   - `runtime/hub/frontend/apps/home/vite.config.ts`
   - `runtime/hub/frontend/apps/spawn/vite.config.ts`
   - Keep dev behavior at `/`, but use `./` for build output so Jinja-provided entry URLs determine the runtime static prefix and follow-on assets/chunks resolve relative to that URL under both `/hub/...` and `/rlc/hub/...`

## Testing

- [x] `docker build -f dockerfiles/Hub/Dockerfile -t ghcr.io/amdresearch/auplc-hub:latest .`
- [x] Temporary local Helm rollout with `--set hub.baseUrl=/rlc/`
- [x] `/rlc/hub/login` renders correctly and requests `/rlc/hub/static/announcement.txt` with HTTP 200
- [x] `/rlc/hub/metrics` returns HTTP 200
- [x] `helm template` renders ServiceMonitor metrics path as `/rlc/hub/metrics`
- [x] `python -m py_compile runtime/hub/core/authenticators/jwt.py`
- [x] Built Vite `index.html` files now emit relative `./assets/...` URLs
- [x] Live static app checks under `/rlc/hub/static/...` return HTTP 200 for:
  - `admin-ui/index.html`, `admin-ui/assets/index.js`, `admin-ui/assets/index.css`
  - `home-ui/index.html`, `home-ui/assets/index.js`, `home-ui/assets/index.css`
  - `spawn-ui/index.html`, `spawn-ui/assets/index.js`, `spawn-ui/assets/index.css`