### PR TITLE
fix: upgrade JupyterHub to 5.4.4 and patch auto-login open redirect

### DIFF
--- a/auplc-installer
+++ b/auplc-installer
@@ -64,14 +64,14 @@ PLAIN_CUSTOM_NAMES=("auplc-hub" "auplc-default")
 
 # External images required by JupyterHub at runtime
 EXTERNAL_IMAGES=(
-    "quay.io/jupyterhub/k8s-hub:4.1.0"
-    "quay.io/jupyterhub/configurable-http-proxy:4.6.3"
-    "quay.io/jupyterhub/k8s-secret-sync:4.1.0"
-    "quay.io/jupyterhub/k8s-network-tools:4.1.0"
-    "quay.io/jupyterhub/k8s-image-awaiter:4.1.0"
-    "quay.io/jupyterhub/k8s-singleuser-sample:4.1.0"
-    "registry.k8s.io/kube-scheduler:v1.30.8"
-    "registry.k8s.io/pause:3.10"
+    "quay.io/jupyterhub/k8s-hub:4.3.3"
+    "quay.io/jupyterhub/configurable-http-proxy:5.2.0"
+    "quay.io/jupyterhub/k8s-secret-sync:4.3.3"
+    "quay.io/jupyterhub/k8s-network-tools:4.3.3"
+    "quay.io/jupyterhub/k8s-image-awaiter:4.3.3"
+    "quay.io/jupyterhub/k8s-singleuser-sample:4.3.3"
+    "registry.k8s.io/kube-scheduler:v1.30.14"
+    "registry.k8s.io/pause:3.10.1"
     # traefik is already included in the K3s airgap images bundle
     "curlimages/curl:8.5.0"
     "alpine/git:2.47.2"

--- a/dockerfiles/Base/Dockerfile.cpu
+++ b/dockerfiles/Base/Dockerfile.cpu
@@ -25,7 +25,9 @@ ARG BASE_IMAGE=quay.io/jupyter/base-notebook
 FROM $BASE_IMAGE
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
-ARG JUPYTERHUB_VERSION=""
+# Align jupyterhub package with the Hub image version (runtime/chart/Chart.yaml
+# appVersion) so the singleuser <-> hub protocol stays in sync.
+ARG JUPYTERHUB_VERSION="5.4.4"
 ARG PIP_INDEX_URL=
 
 # Set pip index URL if specified

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -144,12 +144,14 @@ RUN WHL_TARGET="${PYTORCH_WHL_TARGET}" && \
     fi
 
 # Install JupyterHub and related packages
+# jupyterhub must match the Hub image version to ensure singleuser <-> hub
+# protocol compatibility. See runtime/chart/Chart.yaml appVersion.
 RUN pip3 install --no-cache-dir \
-    jupyterhub==4.0.2 \
+    jupyterhub==5.4.4 \
     jupyterlab==4.5.6 \
     notebook==7.5.5 \
-    ipywidgets==8.1.1 \
-    ipykernel==6.27.1 \
+    ipywidgets==8.1.8 \
+    ipykernel==6.31.0 \
     matplotlib \
     uv \
     seaborn \

--- a/dockerfiles/Hub/Dockerfile
+++ b/dockerfiles/Hub/Dockerfile
@@ -19,7 +19,7 @@
 
 # Global build arguments
 ARG NODE_IMAGE=node:20-alpine
-ARG HUB_IMAGE=quay.io/jupyterhub/k8s-hub:4.1.0
+ARG HUB_IMAGE=quay.io/jupyterhub/k8s-hub:4.3.3
 ARG NPM_REGISTRY=
 ARG PIP_INDEX_URL=
 

--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -28,7 +28,7 @@ GPU_BASE_IMAGE ?= ghcr.io/amdresearch/auplc-base:latest
 BUILD_ARGS :=
 ifneq ($(MIRROR_PREFIX),)
   BUILD_ARGS += --build-arg NODE_IMAGE=$(MIRROR_PREFIX)/docker.io/library/node:20-alpine
-  BUILD_ARGS += --build-arg HUB_IMAGE=$(MIRROR_PREFIX)/quay.io/jupyterhub/k8s-hub:4.1.0
+  BUILD_ARGS += --build-arg HUB_IMAGE=$(MIRROR_PREFIX)/quay.io/jupyterhub/k8s-hub:4.3.3
 endif
 ifneq ($(MIRROR_PIP),)
   BUILD_ARGS += --build-arg PIP_INDEX_URL=$(MIRROR_PIP)
@@ -76,7 +76,7 @@ hub:
 		echo "-------------------------------------------";
 
 	cd Hub && NODE_IMAGE="$(if $(MIRROR_PREFIX),$(MIRROR_PREFIX)/docker.io/library/node:20-alpine,)" \
-		HUB_IMAGE="$(if $(MIRROR_PREFIX),$(MIRROR_PREFIX)/quay.io/jupyterhub/k8s-hub:4.1.0,)" \
+		HUB_IMAGE="$(if $(MIRROR_PREFIX),$(MIRROR_PREFIX)/quay.io/jupyterhub/k8s-hub:4.3.3,)" \
 		PIP_INDEX_URL="$(MIRROR_PIP)" \
 		NPM_REGISTRY="$(MIRROR_NPM)" \
 		bash ./build.sh

--- a/runtime/chart/Chart.yaml
+++ b/runtime/chart/Chart.yaml
@@ -1,27 +1,27 @@
 annotations:
   artifacthub.io/images: |
-    - image: quay.io/jupyterhub/configurable-http-proxy:4.6.3
+    - image: quay.io/jupyterhub/configurable-http-proxy:5.2.0
       name: configurable-http-proxy
-    - image: quay.io/jupyterhub/k8s-hub:4.1.0
+    - image: quay.io/jupyterhub/k8s-hub:4.3.3
       name: k8s-hub
-    - image: quay.io/jupyterhub/k8s-image-awaiter:4.1.0
+    - image: quay.io/jupyterhub/k8s-image-awaiter:4.3.3
       name: k8s-image-awaiter
-    - image: quay.io/jupyterhub/k8s-network-tools:4.1.0
+    - image: quay.io/jupyterhub/k8s-network-tools:4.3.3
       name: k8s-network-tools
-    - image: quay.io/jupyterhub/k8s-secret-sync:4.1.0
+    - image: quay.io/jupyterhub/k8s-secret-sync:4.3.3
       name: k8s-secret-sync
-    - image: quay.io/jupyterhub/k8s-singleuser-sample:4.1.0
+    - image: quay.io/jupyterhub/k8s-singleuser-sample:4.3.3
       name: k8s-singleuser-sample
-    - image: registry.k8s.io/kube-scheduler:v1.30.8
+    - image: registry.k8s.io/kube-scheduler:v1.30.14
       name: kube-scheduler
-    - image: registry.k8s.io/pause:3.10
+    - image: registry.k8s.io/pause:3.10.1
       name: pause
-    - image: registry.k8s.io/pause:3.10
+    - image: registry.k8s.io/pause:3.10.1
       name: pause
-    - image: traefik:v3.3.1
+    - image: traefik:v3.6.12
       name: traefik
 apiVersion: v2
-appVersion: 5.2.1
+appVersion: 5.4.4
 description: Multi-user Jupyter installation
 home: https://z2jh.jupyter.org
 icon: https://hub.jupyter.org/helm-chart/images/hublogo.svg
@@ -38,4 +38,4 @@ maintainers:
 name: jupyterhub
 sources:
   - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
-version: 4.1.0
+version: 4.3.3

--- a/runtime/chart/values.yaml
+++ b/runtime/chart/values.yaml
@@ -173,7 +173,7 @@ hub:
   extraVolumeMounts: []
   image:
     name: quay.io/jupyterhub/k8s-hub
-    tag: "4.1.0"
+    tag: "4.3.3"
     pullPolicy:
     pullSecrets: []
   resources: {}
@@ -309,7 +309,7 @@ proxy:
       # tag is automatically bumped to new patch versions by the
       # watch-dependencies.yaml workflow.
       #
-      tag: "4.6.3" # https://github.com/jupyterhub/configurable-http-proxy/tags
+      tag: "5.2.0" # https://github.com/jupyterhub/configurable-http-proxy/tags
       pullPolicy:
       pullSecrets: []
     extraCommandLineFlags: []
@@ -367,7 +367,7 @@ proxy:
       # tag is automatically bumped to new patch versions by the
       # watch-dependencies.yaml workflow.
       #
-      tag: "v3.3.1" # ref: https://hub.docker.com/_/traefik?tab=tags
+      tag: "v3.6.12" # ref: https://hub.docker.com/_/traefik?tab=tags
       pullPolicy:
       pullSecrets: []
     hsts:
@@ -419,7 +419,7 @@ proxy:
         type: "RuntimeDefault"
     image:
       name: quay.io/jupyterhub/k8s-secret-sync
-      tag: "4.1.0"
+      tag: "4.3.3"
       pullPolicy:
       pullSecrets: []
     resources: {}
@@ -459,7 +459,7 @@ singleuser:
   networkTools:
     image:
       name: quay.io/jupyterhub/k8s-network-tools
-      tag: "4.1.0"
+      tag: "4.3.3"
       pullPolicy:
       pullSecrets: []
     resources: {}
@@ -512,7 +512,7 @@ singleuser:
       subPath:
   image:
     name: quay.io/jupyterhub/k8s-singleuser-sample
-    tag: "4.1.0"
+    tag: "4.3.3"
     pullPolicy:
     pullSecrets: []
   startTimeout: 300
@@ -644,7 +644,7 @@ scheduling:
       # here. We aim to stay around 1 minor version behind the latest k8s
       # version.
       #
-      tag: "v1.30.8" # ref: https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG
+      tag: "v1.30.14" # ref: https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG
       pullPolicy:
       pullSecrets: []
     nodeSelector: {}
@@ -676,7 +676,7 @@ scheduling:
       #
       # If you update this, also update prePuller.pause.image.tag
       #
-      tag: "3.10"
+      tag: "3.10.1"
       pullPolicy:
       pullSecrets: []
     revisionHistoryLimit:
@@ -742,7 +742,7 @@ prePuller:
     # image and the configuration below relates to the hook-image-awaiter Job
     image:
       name: quay.io/jupyterhub/k8s-image-awaiter
-      tag: "4.1.0"
+      tag: "4.3.3"
       pullPolicy:
       pullSecrets: []
     containerSecurityContext:
@@ -793,7 +793,7 @@ prePuller:
       #
       # If you update this, also update scheduling.userPlaceholder.image.tag
       #
-      tag: "3.10"
+      tag: "3.10.1"
       pullPolicy:
       pullSecrets: []
 

--- a/runtime/hub/core/authenticators/auto_login.py
+++ b/runtime/hub/core/authenticators/auto_login.py
@@ -57,9 +57,16 @@ class AutoLoginAuthenticator(Authenticator):
 
                 self.set_login_cookie(user)
 
-                next_url = self.get_argument("next", "")
-                if not next_url:
-                    next_url = url_path_join(self.hub.base_url, "home")
+                # Resolve the post-login destination via BaseHandler.get_next_url
+                # so the value goes through JupyterHub's _validate_next_url,
+                # which rejects cross-origin targets and normalises path-
+                # confusion payloads (CVE-2026-33709 class). Reading
+                # ``?next=`` directly and calling ``self.redirect`` would be
+                # an open redirect — see the JupyterHub upstream LoginHandler
+                # for the reference flow.
+                next_url = self.get_next_url(
+                    user, default=url_path_join(self.hub.base_url, "home")
+                )
 
                 self.log.info(f"Auto-login: user '{username}' authenticated, redirecting to {next_url}")
                 self.redirect(next_url)

--- a/runtime/hub/core/authenticators/auto_login.py
+++ b/runtime/hub/core/authenticators/auto_login.py
@@ -64,9 +64,7 @@ class AutoLoginAuthenticator(Authenticator):
                 # ``?next=`` directly and calling ``self.redirect`` would be
                 # an open redirect — see the JupyterHub upstream LoginHandler
                 # for the reference flow.
-                next_url = self.get_next_url(
-                    user, default=url_path_join(self.hub.base_url, "home")
-                )
+                next_url = self.get_next_url(user, default=url_path_join(self.hub.base_url, "home"))
 
                 self.log.info(f"Auto-login: user '{username}' authenticated, redirecting to {next_url}")
                 self.redirect(next_url)


### PR DESCRIPTION
## Summary

Closes the open-redirect attack surface on `www.openhw.io` and the dev image in one branch:

1. **Hub upgrade** (`0c551c5`) — bump z2jh chart `4.1.0 → 4.3.3`, JupyterHub `5.2.1 → 5.4.4`. This carries the upstream patch for [CVE-2026-33709](https://github.com/jupyterhub/jupyterhub/security/advisories/GHSA-3vff-hjqv-m7h8) (Open Redirect via `next=` with path-confusion on self-host). Template structure is identical between chart 4.1.0 and 4.3.3, so this is a tag-only bump with no values schema migration.

2. **Singleuser alignment** (`cf8e5ad`) — pin `jupyterhub==5.4.4` in both `Dockerfile.rocm` and `Dockerfile.cpu` so the singleuser-server protocol stays in sync with the upgraded hub, plus minor version bumps for `ipywidgets`/`ipykernel`.

3. **Local open-redirect fix** (`a9a98a2`) — our custom `AutoLoginHandler` read `?next=` and called `self.redirect(...)` verbatim, completely bypassing `_validate_next_url`. This was an open redirect **independent of CVE-2026-33709** — JupyterHub's fix never had a chance to run. Replaced the hand-rolled logic with `BaseHandler.get_next_url(user, default=...)` which invokes the upstream validator.

### Upgraded images

| Image | 4.1.0 | 4.3.3 |
|---|---|---|
| `k8s-hub` | 4.1.0 | 4.3.3 |
| `configurable-http-proxy` | 4.6.3 | 5.2.0 |
| `k8s-secret-sync` / `k8s-network-tools` / `k8s-image-awaiter` / `k8s-singleuser-sample` | 4.1.0 | 4.3.3 |
| `traefik` | v3.3.1 | v3.6.12 |
| `kube-scheduler` | v1.30.8 | v1.30.14 |
| `pause` | 3.10 | 3.10.1 |

### Files touched

- `runtime/chart/Chart.yaml` — chart version + image annotations
- `runtime/chart/values.yaml` — 10 image tags
- `dockerfiles/Hub/Dockerfile` + `dockerfiles/Makefile` — hub base image arg
- `auplc-installer` — offline install image list
- `dockerfiles/Base/Dockerfile.rocm` + `Dockerfile.cpu` — singleuser jupyter packages
- `runtime/hub/core/authenticators/auto_login.py` — `next=` validation

## Risk assessment

- **Scope of CVE-2026-33709 on production (`www.openhw.io`)**: Low — required a self-host path-confusion payload that only a few browsers follow. Patched with this PR.
- **AutoLoginHandler open redirect**: Only impacts `authMode: auto-login` deployments, which per the values.yaml comment are _"single-node dev / personal learning environments"_. Production uses `multi` auth and was never exposed to this particular bug.
- **No API changes** in JupyterHub 5.2.1 → 5.4.4 that affect our custom code (verified against upstream changelog).
- **CHP 4.x → 5.x is a major-version bump** — upstream documents API compatibility, but worth smoke-testing in staging.

## Test plan

- [x] `helm lint ./runtime/chart -f ./runtime/values.yaml` passes
- [x] `helm template ./runtime/chart -f ./runtime/values.yaml` renders with new image tags
- [x] Dev cluster: `curl -I /hub/login` → `x-jupyterhub-version: 5.4.4`
- [x] Dev cluster: `curl /hub/login?next=https://evil.example.com/pwn` → `Location: /hub/home` (was `Location: https://evil.example.com/pwn` before)
- [x] Dev cluster: `curl /hub/login?next=/hub/home` → `Location: /hub/home` (benign path unchanged)
- [ ] Staging: rebuild hub/base/course images, `helm upgrade`, smoke-test spawn + GitHub OAuth + notebook server
- [ ] Production: deploy, re-run `curl -I https://www.openhw.io/hub/login | grep x-jupyterhub-version` expecting 5.4.4

## Follow-up items (out of scope for this PR)

The security audit also flagged these — will be separate PRs:

- Remove `cdn.tailwindcss.com` from `login.html` (supply-chain risk)
- Add HSTS / X-Content-Type-Options / Referrer-Policy / stronger CSP
- Cookie `Secure` + `SameSite` flags
- `announcement.txt` rendered via `innerHTML` → switch to `textContent`

Made with [Cursor](https://cursor.com)