### PR TITLE
ci: make docker image names fork-configurable via IMAGE_NAME_SUFFIX

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -95,12 +95,32 @@ jobs:
       gpu-map: ${{ steps.config.outputs.gpu-map }}
       default-gpu-target: ${{ steps.config.outputs.default }}
       course-list: ${{ steps.config.outputs.courses }}
+      image-name-suffix: ${{ steps.names.outputs.suffix }}
+      hub-image: ${{ steps.names.outputs.hub }}
+      base-cpu-image: ${{ steps.names.outputs.base-cpu }}
+      base-gpu-image: ${{ steps.names.outputs.base-gpu }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Set registry prefix
         id: registry
         run: echo "prefix=ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve image names
+        id: names
+        env:
+          # Repo-level variable. Leave unset in upstream (public) repo → "" → names
+          # stay as auplc-base / auplc-cv / … Set to e.g. "-dev" in a fork so every
+          # published image (and the BASE_IMAGE consumed by course builds) flips to
+          # auplc-base-dev / auplc-cv-dev / …  Keeps forks from colliding with
+          # upstream packages and lets dev branches self-reference their own base.
+          SUFFIX: ${{ vars.IMAGE_NAME_SUFFIX }}
+          REGISTRY: ${{ steps.registry.outputs.prefix }}
+        run: |
+          echo "suffix=${SUFFIX}"        >> "$GITHUB_OUTPUT"
+          echo "hub=${REGISTRY}/auplc-hub${SUFFIX}"         >> "$GITHUB_OUTPUT"
+          echo "base-cpu=${REGISTRY}/auplc-default${SUFFIX}" >> "$GITHUB_OUTPUT"
+          echo "base-gpu=${REGISTRY}/auplc-base${SUFFIX}"    >> "$GITHUB_OUTPUT"
 
       - name: Check if tag push
         id: check
@@ -177,7 +197,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ needs.changes.outputs.registry }}/auplc-hub
+          images: ${{ needs.changes.outputs.hub-image }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
@@ -230,7 +250,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ needs.changes.outputs.registry }}/auplc-default
+          images: ${{ needs.changes.outputs.base-cpu-image }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
@@ -310,7 +330,7 @@ jobs:
         id: meta-suffixed
         uses: docker/metadata-action@v5
         with:
-          images: ${{ needs.changes.outputs.registry }}/auplc-base
+          images: ${{ needs.changes.outputs.base-gpu-image }}
           flavor: |
             suffix=-${{ steps.suffix.outputs.tag_suffix }}
           tags: |
@@ -329,7 +349,7 @@ jobs:
         id: meta-default
         uses: docker/metadata-action@v5
         with:
-          images: ${{ needs.changes.outputs.registry }}/auplc-base
+          images: ${{ needs.changes.outputs.base-gpu-image }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
@@ -426,8 +446,11 @@ jobs:
 
       - name: Derive image name and tag suffix
         id: meta-inputs
+        env:
+          NAME_SUFFIX: ${{ needs.changes.outputs.image-name-suffix }}
         run: |
-          echo "image_name=auplc-$(echo '${{ matrix.course }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+          COURSE_LC=$(echo '${{ matrix.course }}' | tr '[:upper:]' '[:lower:]')
+          echo "image_name=auplc-${COURSE_LC}${NAME_SUFFIX}" >> "$GITHUB_OUTPUT"
           echo "tag_suffix=${{ matrix.gpu_target }}" >> "$GITHUB_OUTPUT"
 
       - name: Determine base image tag
@@ -442,7 +465,10 @@ jobs:
           else
             BRANCH=$(echo "${GITHUB_REF##refs/heads/}" | tr '/' '-')
           fi
-          echo "image=${{ needs.changes.outputs.registry }}/auplc-base:${BRANCH}-${SUFFIX}" >> "$GITHUB_OUTPUT"
+          # Pull the base image from THIS repo's package (auplc-base or auplc-base-dev)
+          # at the tag built by this same workflow run for the current branch —
+          # never fall back to upstream auplc-base.
+          echo "image=${{ needs.changes.outputs.base-gpu-image }}:${BRANCH}-${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata (target-suffixed tags)
         id: meta-suffixed


### PR DESCRIPTION
## Summary

Course image builds always pulled `BASE_IMAGE=…/auplc-base:<branch>-<gfx>`, so a fork publishing its own base under a different image name (e.g. `auplc-base-dev` for a private `aup-learning-cloud-dev` fork) could never produce a course image whose `FROM` matched the branch's own base — the course build kept reaching for a `auplc-base:*` tag that the fork doesn't publish.

This PR introduces a single opt-in switch — the repo-level Actions variable `IMAGE_NAME_SUFFIX` — that threads a suffix through every published image path **and** the `BASE_IMAGE` consumed by course builds. A fork can namespace all published images (hub / base-cpu / base-gpu / four courses) with one configuration line and have branch-build course images automatically `FROM` the same-branch base.

Upstream behaviour is unchanged: the variable is unset → suffix is `""` → image names stay `auplc-hub` / `auplc-default` / `auplc-base` / `auplc-cv` / `auplc-dl` / `auplc-llm` / `auplc-physim`. No packages are renamed, no downstream consumers break.

## Changes

- New `Resolve image names` step in the `changes` job centralises every published image path as job outputs (`hub-image`, `base-cpu-image`, `base-gpu-image`) and derives an `image-name-suffix` output from `vars.IMAGE_NAME_SUFFIX`.
- Replaced hardcoded `auplc-hub` / `auplc-default` / `auplc-base` in all four ``docker/metadata-action`` steps (hub, base-cpu, base-gpu suffixed, base-gpu unsuffixed) with the new outputs.
- Course image-name derivation now appends the suffix, so e.g. `auplc-cv` becomes `auplc-cv-dev` in a fork.
- **Root fix**: `Determine base image tag` now reuses `needs.changes.outputs.base-gpu-image` instead of a hardcoded `auplc-base`, guaranteeing base↔course alignment inside one workflow run regardless of fork naming.
- `auplc-installer`, `runtime/values.yaml`, `dockerfiles/Makefile`, and course `Dockerfile` `ARG BASE_IMAGE` defaults are **intentionally not touched** — the single-node offline bundle flow keeps working against the canonical public package names.

## Testing

- Diff is 32 insertions / 6 deletions across only `.github/workflows/docker-build.yml`; no other file in the repo references the affected image names in a way that this change can break.
- Sanity-checked the workflow file for stray hardcoded `auplc-*` references: only comments and the three lines inside the new `Resolve image names` step remain (as intended).
- CI verification on this PR: with `IMAGE_NAME_SUFFIX` unset, published image names and tags should be byte-identical to a pre-PR run on `main`.
- Fork verification (outside this repo): setting `vars.IMAGE_NAME_SUFFIX=-dev` should publish `auplc-base-dev:<branch>-<gfx>` and have the course jobs successfully pull that exact tag as `BASE_IMAGE`.

## Files Changed

- `.github/workflows/docker-build.yml`

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [ ] Tested on local Kubernetes cluster — N/A, workflow-only change; validated via diff review and CI on this PR
- [ ] Documentation links updated — no user-facing docs changed; fork-onboarding note (how to set the repo variable) can be added if reviewers want it

Made with [Cursor](https://cursor.com)