### PR TITLE
security: add CSP header and fix tornado_settings clobber bug

### DIFF
--- a/runtime/hub/core/jupyterhub_config.py
+++ b/runtime/hub/core/jupyterhub_config.py
@@ -60,16 +60,6 @@ c = get_config()  # noqa: F821
 
 setup_hub(c)
 
-# Hub allowed origins: set CORS headers on the Hub's Tornado server
-_hub_config = HubConfig.get()
-_hub_allowed_origins = _hub_config.hub_network.allowedOrigins
-if _hub_allowed_origins:
-    _origin_val = "*" if "*" in _hub_allowed_origins else ", ".join(_hub_allowed_origins)
-    _ts = dict(c.JupyterHub.tornado_settings or {})
-    _ts.setdefault("headers", {})["Access-Control-Allow-Origin"] = _origin_val
-    c.JupyterHub.tornado_settings = _ts
-    print(f"[CONFIG] Hub allowedOrigins: {_hub_allowed_origins}")
-
 # =============================================================================
 # Z2JH Standard Configuration (Kubernetes-specific)
 # =============================================================================
@@ -94,7 +84,38 @@ c.ConfigurableHTTPProxy.should_start = False
 # Hub settings
 c.JupyterHub.cleanup_servers = False
 c.JupyterHub.last_activity_interval = 60
-c.JupyterHub.tornado_settings = {"slow_spawn_timeout": 0}
+
+# Base tornado settings — always applied.
+# Security note: 'unsafe-inline' is required because JupyterHub injects inline
+# scripts (e.g. darkmode observer) and Cloudflare Bot Fight also injects inline
+# JS that cannot be predicted ahead of time. Removing 'unsafe-inline' would
+# require nonce support coordinated across Hub and Cloudflare, tracked as a
+# future hardening task. This policy still prevents loading scripts/resources
+# from arbitrary external origins, which is the primary CSP risk.
+_BASE_TORNADO_SETTINGS: dict = {
+    "slow_spawn_timeout": 0,
+    "headers": {
+        "Content-Security-Policy": (
+            "default-src 'self'; "
+            "script-src 'self' 'unsafe-inline'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data:; "
+            "font-src 'self'; "
+            "frame-ancestors 'none'; "
+            "report-uri /hub/security/csp-report"
+        ),
+    },
+}
+
+# Hub allowed origins: merge CORS header into tornado_settings without clobbering.
+_hub_config = HubConfig.get()
+_hub_allowed_origins = _hub_config.hub_network.allowedOrigins
+if _hub_allowed_origins:
+    _origin_val = "*" if "*" in _hub_allowed_origins else ", ".join(_hub_allowed_origins)
+    _BASE_TORNADO_SETTINGS.setdefault("headers", {})["Access-Control-Allow-Origin"] = _origin_val
+    print(f"[CONFIG] Hub allowedOrigins: {_hub_allowed_origins}")
+
+c.JupyterHub.tornado_settings = _BASE_TORNADO_SETTINGS
 
 # Database configuration
 db_type = z2jh.get_config("hub.db.type")


### PR DESCRIPTION
## Summary

- Add a complete `Content-Security-Policy` response header via `tornado_settings` in `jupyterhub_config.py`, covering `default-src`, `script-src`, `style-src`, `img-src`, `font-src`, and `frame-ancestors`. This upgrades the Hub from only having `frame-ancestors 'none'` to a full origin-allowlist policy.
- Fix a silent bug where the `allowedOrigins` CORS block wrote to `tornado_settings` early but a later unconditional assignment (`tornado_settings = {"slow_spawn_timeout": 0}`) clobbered it entirely. Both settings are now merged into a single `_BASE_TORNADO_SETTINGS` dict applied once.

## Security audit context

Identified in white-box security audit of `www.openhw.io` (2026-04-25):
- **Finding #5** — CSP missing `script-src` / `default-src` on HTML handler (Medium)
- **White-box observation** — `jupyterhub_config.py` L97 silent clobber bug (tornado_settings overwrite)

Related JIRA: AUPPM-57 (Security Headers — Cloudflare), AUPPM-56 (x-jupyterhub-version removal)

## CSP policy applied

```
default-src 'self';
script-src 'self' 'unsafe-inline';
style-src 'self' 'unsafe-inline';
img-src 'self' data:;
font-src 'self';
frame-ancestors 'none';
report-uri /hub/security/csp-report
```

> `'unsafe-inline'` is required because JupyterHub injects inline scripts (darkmode observer) and Cloudflare Bot Fight also injects dynamic inline JS. Removing it requires nonce support coordinated across Hub and Cloudflare — tracked as a future hardening task.

## Test plan

- [ ] Deploy Hub image with this change to a staging/dev environment
- [ ] Verify `Content-Security-Policy` header is present on `/hub/login`, `/hub/static/*`, and `/hub/api/` responses
- [ ] Verify darkmode toggle still works (inline script not blocked)
- [ ] Verify `allowedOrigins` CORS header is correctly set when `hub.network.allowedOrigins` is configured (regression test for the clobber fix)
- [ ] Check browser console for any CSP violation reports on `/hub/security/csp-report`

Made with [Cursor](https://cursor.com)