### PR TITLE
security: harden _xsrf cookie with Secure and SameSite=Lax

### DIFF
--- a/runtime/hub/core/jupyterhub_config.py
+++ b/runtime/hub/core/jupyterhub_config.py
@@ -96,6 +96,13 @@ c.JupyterHub.cleanup_servers = False
 c.JupyterHub.last_activity_interval = 60
 c.JupyterHub.tornado_settings = {"slow_spawn_timeout": 0}
 
+# Harden _xsrf session cookie.
+# - Secure: only transmitted over HTTPS (safe because HSTS is enforced site-wide).
+# - SameSite=Lax: blocks cross-site POST forgery while allowing top-level navigations.
+# - HttpOnly is intentionally omitted: JupyterHub's frontend JS reads _xsrf to
+#   include it in form submissions, so HttpOnly would break the XSRF protection.
+c.JupyterHub.cookie_options = {"Secure": True, "SameSite": "Lax"}
+
 # Database configuration
 db_type = z2jh.get_config("hub.db.type")
 if db_type == "sqlite-pvc":


### PR DESCRIPTION
## Summary

Add `cookie_options` to `jupyterhub_config.py` to set `Secure` and `SameSite=Lax` on the `_xsrf` session cookie.

## Security audit context

Identified during white-box security audit of `www.openhw.io` on 2026-04-25:
- **Finding #6** (Medium) — `_xsrf` cookie missing `Secure` and `SameSite` attributes

Current cookie (pre-fix):
```
Set-Cookie: _xsrf=…; Max-Age=3600; Path=/hub/
```

## Fix

```python
# runtime/hub/core/jupyterhub_config.py
c.JupyterHub.cookie_options = {"Secure": True, "SameSite": "Lax"}
```

After fix:
```
Set-Cookie: _xsrf=…; Max-Age=3600; Path=/hub/; Secure; SameSite=Lax
```

**Why `Secure`:** Safe to enable because HSTS (`max-age=31536000; includeSubDomains`) is already enforced site-wide via Cloudflare. The cookie will never be sent over plain HTTP.

**Why `SameSite=Lax`:** Blocks cross-site POST-based CSRF attacks while still allowing top-level navigations (e.g. OAuth redirects back to the Hub).

**Why NOT `HttpOnly`:** JupyterHub's frontend JS must read `_xsrf` to include it in form submissions — setting `HttpOnly` would silently break the XSRF protection mechanism itself.

## Test plan

- [ ] Deploy Hub image with this change to staging/dev
- [ ] Verify `Set-Cookie` response on `/hub/login` includes `Secure; SameSite=Lax`
- [ ] Verify login flow works end-to-end (form submission with `_xsrf` token intact)
- [ ] Verify OAuth login flow still works (top-level navigation not blocked by `SameSite=Lax`)

## Related

- Security audit canvas: `openhw-security-audit` Finding #6
- AUPPM-58 — CSP + tornado_settings fix (PR#81, separate branch)
- AUPPM-45 — /hub/metrics unauthenticated access (still open)

Made with [Cursor](https://cursor.com)