### PR TITLE
fix: use xsrf_cookie_kwargs to set Secure and SameSite on _xsrf cookie

### DIFF
--- a/runtime/hub/core/jupyterhub_config.py
+++ b/runtime/hub/core/jupyterhub_config.py
@@ -117,12 +117,18 @@ if _hub_allowed_origins:
 
 c.JupyterHub.tornado_settings = _BASE_TORNADO_SETTINGS
 
-# Harden _xsrf session cookie.
-# - Secure: only transmitted over HTTPS (safe because HSTS is enforced site-wide).
-# - SameSite=Lax: blocks cross-site POST forgery while allowing top-level navigations.
-# - HttpOnly is intentionally omitted: JupyterHub's frontend JS reads _xsrf to
-#   include it in form submissions, so HttpOnly would break the XSRF protection.
-c.JupyterHub.cookie_options = {"Secure": True, "SameSite": "Lax"}
+# Harden _xsrf session cookie via Tornado's xsrf_cookie_kwargs.
+# JupyterHub.cookie_options only affects Hub session cookies; the _xsrf cookie
+# is managed directly by Tornado and requires xsrf_cookie_kwargs in
+# tornado_settings to set Secure and SameSite.
+# - Secure: safe because HSTS is enforced site-wide via Cloudflare.
+# - SameSite=Lax: blocks cross-site POST CSRF while allowing OAuth top-level redirects.
+# - HttpOnly is intentionally omitted: JupyterHub's frontend JS must read _xsrf
+#   to include it in form submissions.
+c.JupyterHub.tornado_settings = {
+    **c.JupyterHub.tornado_settings,
+    "xsrf_cookie_kwargs": {"secure": True, "samesite": "Lax"},
+}
 
 # Database configuration
 db_type = z2jh.get_config("hub.db.type")


### PR DESCRIPTION
## Summary

Corrects the approach used in PR#82 for hardening the `_xsrf` cookie.

**Problem with PR#82:** `c.JupyterHub.cookie_options` only affects JupyterHub's own session cookies (e.g. `username-xxx`). The `_xsrf` cookie is managed directly by Tornado and is unaffected by `cookie_options`.

**Correct fix:** Use `tornado_settings["xsrf_cookie_kwargs"]` which Tornado reads when setting the `_xsrf` cookie.

```python
# Before (PR#82 — ineffective for _xsrf)
c.JupyterHub.cookie_options = {"Secure": True, "SameSite": "Lax"}

# After (this PR — correct)
c.JupyterHub.tornado_settings = {
    **c.JupyterHub.tornado_settings,
    "xsrf_cookie_kwargs": {"secure": True, "samesite": "Lax"},
}
```

**Expected result:**
```
Set-Cookie: _xsrf=…; Max-Age=3600; Path=/hub/; Secure; SameSite=Lax
```

## Security audit context

Finding #6 (Medium) — white-box audit of `www.openhw.io` on 2026-04-25.
JIRA: [AUPPM-59](https://amd.atlassian.net/browse/AUPPM-59)

## Test plan

- [ ] Deploy and verify `Set-Cookie` on `/hub/login` includes `Secure; SameSite=Lax`
- [ ] Verify login and OAuth flow still work end-to-end

Made with [Cursor](https://cursor.com)