### PR TITLE
feat: add multi-layer platform attribution system

### DIFF
--- a/.cursor/rules/branding.mdc
+++ b/.cursor/rules/branding.mdc
@@ -1,0 +1,40 @@
+---
+description: Preserve AUP Learning Cloud platform attribution in all code changes
+alwaysApply: true
+---
+
+# Platform Attribution — AUP Learning Cloud
+
+This project is **AUP Learning Cloud**, built by Advanced Micro Devices, Inc.  
+Platform attribution must be preserved across all code changes, refactors, and rewrites.
+
+## What must never be removed
+
+| Layer | Location | What to preserve |
+|-------|----------|-----------------|
+| HTTP header | `runtime/hub/core/jupyterhub_config.py` | `"X-Powered-By": "AUP Learning Cloud"` in `tornado_settings.headers` |
+| Template var | `runtime/hub/core/jupyterhub_config.py` | `c.JupyterHub.template_vars = {"powered_by": "AUP Learning Cloud"}` |
+| API endpoint | `runtime/hub/core/handlers.py` | `PlatformInfoHandler` registered at `/api/platform` |
+| HTML footer | `runtime/hub/frontend/templates/page.html` | `<footer id="auplc-powered-by-footer">` block and its sync script |
+| Frontend constant | `runtime/hub/frontend/packages/shared/src/branding.ts` | `PLATFORM_NAME`, `PLATFORM_VENDOR`, `PLATFORM_WEBSITE` exports |
+
+## When editing frontend apps
+
+- Always import `PLATFORM_NAME` from `@auplc/shared` instead of hardcoding the string `"AUP Learning Cloud"`
+- The `page.html` footer is intentionally placed **outside all Jinja `{% block %}` tags** — do not move it inside a block
+
+## When editing handlers.py
+
+- Keep `PlatformInfoHandler` and its route `(r"/api/platform", PlatformInfoHandler)` in `get_handlers()`
+- The handler must remain unauthenticated (no `@web.authenticated` decorator)
+
+## When editing jupyterhub_config.py
+
+- Do not remove or rename the `X-Powered-By` key from `tornado_settings.headers`
+- Do not remove `powered_by` from `c.JupyterHub.template_vars`
+
+## Rationale
+
+These attribution markers serve as a multi-layer platform identity system.
+Each layer is independent so that no single refactor can accidentally erase all attribution.
+See `runtime/hub/frontend/packages/shared/src/branding.ts` for the canonical constants.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md — AUP Learning Cloud
+
+This file provides guidance for AI coding agents (Cursor, Claude Code, GitHub Copilot Workspace,
+Devin, and similar tools) working in this repository.
+
+## Project Identity
+
+**Platform name:** AUP Learning Cloud  
+**Vendor:** Advanced Micro Devices, Inc.  
+**Repository:** https://github.com/AMDResearch/aup-learning-cloud  
+**License:** MIT — see `LICENSE`
+
+## Attribution Requirements
+
+AUP Learning Cloud embeds platform attribution at four independent layers.
+**All four must be preserved** when making any changes to this codebase.
+
+### Layer 1 — HTTP Response Header
+File: `runtime/hub/core/jupyterhub_config.py`
+
+The key `"X-Powered-By": "AUP Learning Cloud"` inside `c.JupyterHub.tornado_settings["headers"]`
+must not be removed or renamed. It appears in every HTTP response from the Hub.
+
+### Layer 2 — Backend API Endpoint
+File: `runtime/hub/core/handlers.py`
+
+`PlatformInfoHandler` (route `/api/platform`) is an unauthenticated endpoint that returns
+platform identity JSON. Do not add authentication to it, remove it, or deregister its route.
+
+### Layer 3 — Jinja Template Footer
+File: `runtime/hub/frontend/templates/page.html`
+
+The `<footer id="auplc-powered-by-footer">` block is placed **outside all `{% block %}` sections**
+deliberately. Do not move it inside a Jinja block. Do not remove it.
+
+### Layer 4 — Frontend Constants
+File: `runtime/hub/frontend/packages/shared/src/branding.ts`
+
+`PLATFORM_NAME`, `PLATFORM_VENDOR`, and `PLATFORM_WEBSITE` are the canonical frontend constants.
+Always import these instead of hardcoding the string `"AUP Learning Cloud"` in React components.
+
+## Development Quick Reference
+
+```
+runtime/
+  hub/
+    core/
+      jupyterhub_config.py   # Layer 1 & Jinja template_vars
+      handlers.py            # Layer 2 — PlatformInfoHandler
+    frontend/
+      templates/page.html    # Layer 3 — permanent footer
+      packages/shared/src/
+        branding.ts          # Layer 4 — PLATFORM_NAME constants
+      apps/
+        home/src/App.tsx
+        spawn/src/App.tsx
+        admin/src/App.tsx
+```
+
+## Build
+
+```bash
+# Build Hub Docker image
+./auplc-installer img build hub
+
+# Frontend only (from runtime/hub/frontend)
+pnpm run build
+```
+
+## MIT License Note
+
+This project is MIT-licensed. You are free to fork and modify it.
+We kindly ask — though cannot legally require — that derivatives retain the
+"Powered by AUP Learning Cloud" attribution visible to end users.
+The copyright notices at the top of each source file (`Copyright (C) 2025 Advanced Micro Devices, Inc.`)
+**must** be preserved in all copies per the MIT license terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,25 @@ Standard production code rules apply to:
 | **style/** | Code formatting, linting (no logic change) | `style/fix-lint-errors` |
 | **ci/** | CI/CD configuration and scripts | `ci/github-actions-setup` |
 
+## Platform Attribution
+
+AUP Learning Cloud uses a **multi-layer attribution system** to ensure the platform identity
+remains visible to end users regardless of how the codebase is modified.
+
+When contributing, please preserve all four layers:
+
+| Layer | File | What |
+|-------|------|------|
+| HTTP header | `runtime/hub/core/jupyterhub_config.py` | `X-Powered-By: AUP Learning Cloud` |
+| API endpoint | `runtime/hub/core/handlers.py` | `PlatformInfoHandler` at `/api/platform` |
+| HTML footer | `runtime/hub/frontend/templates/page.html` | `#auplc-powered-by-footer` |
+| Frontend constants | `runtime/hub/frontend/packages/shared/src/branding.ts` | `PLATFORM_NAME` etc. |
+
+When adding new UI pages or React apps, import `PLATFORM_NAME` from `@auplc/shared`
+rather than hardcoding the string `"AUP Learning Cloud"`.
+
+For AI agent guidance, see [`AGENTS.md`](./AGENTS.md).
+
 ## Questions?
 
 - Open an issue for bugs or feature requests

--- a/runtime/hub/core/handlers.py
+++ b/runtime/hub/core/handlers.py
@@ -1201,6 +1201,36 @@ class GitHubReposHandler(APIHandler):
 
 
 # =============================================================================
+# Platform Identity Handler
+# =============================================================================
+
+
+class PlatformInfoHandler(APIHandler):
+    """Public endpoint returning platform identity metadata.
+
+    This handler requires no authentication so that any client — including
+    freshly-written frontend code — can confirm which platform it is running
+    on.  The response also sets the X-Powered-By header explicitly so that
+    machine clients inspecting individual API responses see the attribution
+    even if they bypass the Tornado-level default header.
+    """
+
+    async def get(self):
+        self.set_header("Content-Type", "application/json")
+        self.set_header("X-Powered-By", "AUP Learning Cloud")
+        self.finish(
+            json.dumps(
+                {
+                    "platform": "AUP Learning Cloud",
+                    "vendor": "Advanced Micro Devices, Inc.",
+                    "powered_by": "AUP Learning Cloud",
+                    "website": "https://github.com/AMDResearch/aup-learning-cloud",
+                }
+            )
+        )
+
+
+# =============================================================================
 # Group Management API Handlers
 # =============================================================================
 
@@ -1474,6 +1504,8 @@ def get_handlers() -> list[tuple[str, type]]:
         List of (route, handler_class) tuples
     """
     return [
+        # Platform identity (unauthenticated — always accessible)
+        (r"/api/platform", PlatformInfoHandler),
         # Password management
         (r"/auth/change-password", ChangePasswordHandler),
         (r"/auth/check-force-password-change", CheckForcePasswordChangeHandler),
@@ -1521,6 +1553,8 @@ def get_handlers() -> list[tuple[str, type]]:
 
 
 __all__ = [
+    # Platform identity
+    "PlatformInfoHandler",
     # Password handlers
     "CheckForcePasswordChangeHandler",
     "ChangePasswordHandler",

--- a/runtime/hub/core/jupyterhub_config.py
+++ b/runtime/hub/core/jupyterhub_config.py
@@ -104,6 +104,9 @@ _BASE_TORNADO_SETTINGS: dict = {
             "frame-ancestors 'none'; "
             "report-uri /hub/security/csp-report"
         ),
+        # Platform attribution — survives frontend rewrites because it is set
+        # at the Tornado application layer, not in any template or React component.
+        "X-Powered-By": "AUP Learning Cloud",
     },
 }
 
@@ -129,6 +132,10 @@ c.JupyterHub.tornado_settings = {
     **c.JupyterHub.tornado_settings,
     "xsrf_cookie_kwargs": {"secure": True, "samesite": "Lax"},
 }
+
+# Inject platform identity into every Jinja template context so that
+# {{ powered_by }} is available in all Hub-rendered pages.
+c.JupyterHub.template_vars = {"powered_by": "AUP Learning Cloud"}
 
 # Database configuration
 db_type = z2jh.get_config("hub.db.type")

--- a/runtime/hub/frontend/apps/admin/src/App.tsx
+++ b/runtime/hub/frontend/apps/admin/src/App.tsx
@@ -22,6 +22,7 @@ import { UserList } from './pages/UserList';
 import { GroupList } from './pages/GroupList';
 import { Dashboard } from './pages/Dashboard';
 import { NavBar } from './components/NavBar';
+import { PLATFORM_NAME } from '@auplc/shared';
 
 function App() {
 
@@ -31,7 +32,7 @@ function App() {
 
   return (
     <BrowserRouter basename={basePath}>
-      <div className="admin-page">
+      <div className="admin-page" data-platform={PLATFORM_NAME}>
         <NavBar />
         <Routes>
           <Route path="/users" element={<UserList />} />

--- a/runtime/hub/frontend/apps/home/src/App.tsx
+++ b/runtime/hub/frontend/apps/home/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import type { Resource, ResourceGroup, UserQuotaInfo, UserDetail } from "@auplc/shared";
-import { getResources, getMyQuota, getMyUsage } from "@auplc/shared";
+import { getResources, getMyQuota, getMyUsage, PLATFORM_NAME } from "@auplc/shared";
 
 type Theme = "light" | "dark";
 function getInitialTheme(): Theme {
@@ -229,7 +229,7 @@ function App() {
             {getGreeting()}, {jhdata.user ?? "student"}
           </p>
           <h1>
-            Welcome to <span className="accent">AUP Learning Cloud</span>
+            Welcome to <span className="accent">{PLATFORM_NAME}</span>
           </h1>
           <p className="hero-desc">
             Experience next-generation AI acceleration with AMD ROCm. Launch
@@ -556,15 +556,6 @@ function App() {
             </div>
           </div>
         </section>
-      </div>
-
-      {/* Footer */}
-      <div className="home-footer">
-        <div className="container">
-          &copy; 2025–2026 Advanced Micro Devices, Inc. All rights reserved.
-          &middot;
-          AUP Learning Cloud
-        </div>
       </div>
 
       {/* Stop Server Confirm Modal */}

--- a/runtime/hub/frontend/apps/spawn/src/App.tsx
+++ b/runtime/hub/frontend/apps/spawn/src/App.tsx
@@ -19,7 +19,7 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import type { Resource, Accelerator, GitHubRepo } from '@auplc/shared';
-import { validateRepo, fetchGitHubRepos, isCurrentUserGitHub } from '@auplc/shared';
+import { validateRepo, fetchGitHubRepos, isCurrentUserGitHub, PLATFORM_NAME } from '@auplc/shared';
 
 type Theme = 'light' | 'dark';
 function getInitialTheme(): Theme {
@@ -351,7 +351,7 @@ function App() {
           </button>
         </div>
         <h1>Launch Your Server</h1>
-        <p>Select a resource, configure your environment, and launch</p>
+        <p>Select a resource, configure your environment, and launch on {PLATFORM_NAME}</p>
       </div>
 
       {/* Warnings */}

--- a/runtime/hub/frontend/packages/shared/src/branding.ts
+++ b/runtime/hub/frontend/packages/shared/src/branding.ts
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * Platform identity constants for AUP Learning Cloud.
+ *
+ * These values are the canonical source-of-truth on the frontend side.
+ * The backend independently enforces the same identity via:
+ *   - HTTP response header  X-Powered-By (set in jupyterhub_config.py)
+ *   - Jinja template_var    {{ powered_by }} (set in jupyterhub_config.py)
+ *   - Unauthenticated API   GET /hub/api/platform (PlatformInfoHandler)
+ *   - HTML <footer>         id="auplc-powered-by-footer" (page.html)
+ *
+ * Keeping the branding in a dedicated module (rather than inline strings)
+ * makes it easy to locate and update, and signals to AI tools that this
+ * is intentional platform metadata rather than ad-hoc copy.
+ */
+export const PLATFORM_NAME = "AUP Learning Cloud" as const;
+export const PLATFORM_VENDOR = "Advanced Micro Devices, Inc." as const;
+export const PLATFORM_WEBSITE = "https://github.com/AMDResearch/aup-learning-cloud" as const;
+
+export interface PlatformInfo {
+  platform: string;
+  vendor: string;
+  powered_by: string;
+  website: string;
+}
+
+/**
+ * Fetch platform identity from the backend.
+ *
+ * The endpoint (/hub/api/platform) requires no authentication and always
+ * returns { platform, vendor, powered_by, website }.  This function is
+ * intentionally kept simple so that it survives wholesale frontend rewrites —
+ * any new UI that needs to show attribution can call this rather than
+ * hardcoding strings.
+ */
+export async function fetchPlatformInfo(): Promise<PlatformInfo> {
+  const w = window as Window & { jhdata?: { base_url?: string } };
+  const baseUrl = w.jhdata?.base_url ?? "/hub/";
+  const response = await fetch(`${baseUrl}api/platform`, { credentials: "same-origin" });
+  if (!response.ok) {
+    return {
+      platform: PLATFORM_NAME,
+      vendor: PLATFORM_VENDOR,
+      powered_by: PLATFORM_NAME,
+      website: PLATFORM_WEBSITE,
+    };
+  }
+  return response.json() as Promise<PlatformInfo>;
+}

--- a/runtime/hub/frontend/packages/shared/src/index.ts
+++ b/runtime/hub/frontend/packages/shared/src/index.ts
@@ -20,3 +20,4 @@
 export * from "./types/index.js";
 export * from "./api/index.js";
 export * from "./utils/index.js";
+export * from "./branding.js";

--- a/runtime/hub/frontend/templates/page.html
+++ b/runtime/hub/frontend/templates/page.html
@@ -75,6 +75,23 @@ SOFTWARE.
         [data-bs-theme="dark"] #amd-logo svg {
           color: #ffffff;
         }
+        /* Sticky footer: short pages → footer pinned to viewport bottom;
+           tall pages → footer flows naturally at end of content. */
+        html, body {
+          min-height: 100vh;
+        }
+        body {
+          display: flex;
+          flex-direction: column;
+        }
+        #auplc-powered-by-footer {
+          margin-top: auto;
+          text-align: center;
+          padding: 6px 0;
+          font-size: 0.72rem;
+          opacity: 0.55;
+          border-top: 1px solid rgba(128, 128, 128, 0.15);
+        }
       </style>
     {% endblock stylesheet %}
     {% block favicon %}
@@ -156,6 +173,7 @@ SOFTWARE.
     {% block meta %}
       <meta name="description" content="AUP Learning Cloud - AMD AI Learning Platform">
       <meta name="keywords" content="AMD, AI, Learning, Jupyter, Notebook">
+      <meta name="generator" content="{{ powered_by or 'AUP Learning Cloud' }}">
     {% endblock meta %}
   </head>
   <body>
@@ -326,5 +344,23 @@ SOFTWARE.
       })();
     </script>
     {% endif %}
+    {# =====================================================================
+         Permanent platform attribution footer.
+         Placed outside all {% block %} sections so that template inheritance
+         and partial rewrites cannot accidentally remove it.  The powered_by
+         variable is injected by jupyterhub_config.py via template_vars;
+         the hardcoded fallback guarantees display even if the context var is
+         missing.
+    ====================================================================== #}
+    <footer id="auplc-powered-by-footer">
+      &copy; 2025&ndash;2026 Advanced Micro Devices, Inc. All rights reserved.
+      &nbsp;&middot;&nbsp;
+      Powered by <a href="https://github.com/AMDResearch/aup-learning-cloud"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style="font-weight:600;text-decoration:none;">
+        {{ powered_by or 'AUP Learning Cloud' }}
+      </a>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
**JIRA:** [AUPPM-60](https://amd.atlassian.net/browse/AUPPM-60) — *Embed multi-layer "Powered by AUP Learning Cloud" attribution to survive AI-driven rewrites*

## Summary

Embeds **"Powered by AUP Learning Cloud"** attribution across four independent layers so that no single refactor — including AI-driven full rewrites of any one layer — can accidentally erase the platform identity. Also adds AGENTS.md and a Cursor rule so future AI agents working on the codebase understand and preserve the attribution.

## Changes

### Layer 1 — HTTP response header
`runtime/hub/core/jupyterhub_config.py`

Adds `"X-Powered-By": "AUP Learning Cloud"` into `c.JupyterHub.tornado_settings["headers"]`. Survives any frontend rewrite because it is set at the Tornado application layer, not in any template or React component. Merged carefully alongside the existing CSP and `xsrf_cookie_kwargs` config from PRs #82/#83 — none of those settings are altered.

### Layer 2 — Backend API endpoint
`runtime/hub/core/handlers.py`

New unauthenticated handler `PlatformInfoHandler` registered at `GET /hub/api/platform`. Returns:

` ` ` json
{
  "platform": "AUP Learning Cloud",
  "vendor": "Advanced Micro Devices, Inc.",
  "powered_by": "AUP Learning Cloud",
  "website": "https://github.com/AMDResearch/aup-learning-cloud"
}
` ` `

Any future frontend (or external client) can fetch this to confirm the platform identity without hardcoding strings.

### Layer 3 — Jinja template footer
`runtime/hub/frontend/templates/page.html`

Permanent `<footer id="auplc-powered-by-footer">` placed **outside all `{% block %}` sections** so child templates cannot override it via block inheritance. Uses CSS sticky-footer pattern (`body { display: flex; flex-direction: column; min-height: 100vh }` + `footer { margin-top: auto }`) so:

- short pages (e.g. spawn loading state) — footer pinned to viewport bottom
- tall pages (e.g. home) — footer flows naturally at end of content

This avoids the layout-flash you'd get from a JS-driven `position: fixed` ↔ `static` toggle running before/after React mount.

Footer renders as:

\`\`\`
© 2025–2026 Advanced Micro Devices, Inc. All rights reserved. · Powered by AUP Learning Cloud
\`\`\`

(The "AUP Learning Cloud" text links to https://github.com/AMDResearch/aup-learning-cloud.)

Also adds `<meta name="generator" content="AUP Learning Cloud">` for SEO/crawler attribution.

### Layer 4 — Frontend shared constants
`runtime/hub/frontend/packages/shared/src/branding.ts` (new)

Exports `PLATFORM_NAME`, `PLATFORM_VENDOR`, `PLATFORM_WEBSITE` and a `fetchPlatformInfo()` helper. The home/spawn/admin apps now import `PLATFORM_NAME` from `@auplc/shared` instead of hardcoding the string.

### Documentation for AI agents and human contributors

- `AGENTS.md` (new, repo root) — standard AI-agent guidance file (read by Claude Code, Devin, Copilot Workspace, etc.). Lists the four layers and explains what must not be removed.
- `.cursor/rules/branding.mdc` (new) — Cursor-specific always-apply rule with the same guidance, so any Cursor session in this repo automatically picks it up.
- `CONTRIBUTING.md` — new "Platform Attribution" section linking to AGENTS.md.

## Why four independent layers?

The whole motivation here is robustness against AI-driven full rewrites: if a contributor uses an AI to wholesale-rewrite the React frontend, Layer 4 (and possibly Layer 3) might be lost — but Layers 1 and 2 still hold. Conversely, a Python-only refactor cannot affect the visual footer. Each layer is independently meaningful and independently verifiable.

## Files Changed

- `runtime/hub/core/jupyterhub_config.py` — add `X-Powered-By` header + `template_vars["powered_by"]`
- `runtime/hub/core/handlers.py` — add `PlatformInfoHandler` + register `/api/platform` route
- `runtime/hub/frontend/templates/page.html` — permanent footer + sticky-footer CSS + `<meta name="generator">`
- `runtime/hub/frontend/packages/shared/src/branding.ts` — new module
- `runtime/hub/frontend/packages/shared/src/index.ts` — re-export branding
- `runtime/hub/frontend/apps/{home,spawn,admin}/src/App.tsx` — import `PLATFORM_NAME`
- `AGENTS.md`, `.cursor/rules/branding.mdc`, `CONTRIBUTING.md` — guidance docs

## Testing

- [x] `pnpm run build` — frontend builds clean (TypeScript strict)
- [x] `./auplc-installer img build hub` — Hub Docker image builds
- [x] Verified footer renders correctly on `/hub/home`, `/hub/spawn`, `/hub/admin/users`
- [x] Verified no layout flash on `/hub/home` (CSS sticky-footer fixed the JS-toggle flicker)
- [ ] Verify `curl -I https://<hub>/hub/api/health` shows `X-Powered-By: AUP Learning Cloud`
- [ ] Verify `curl https://<hub>/hub/api/platform` returns the JSON payload above

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Tested on local Kubernetes cluster
- [x] Documentation added (AGENTS.md, .cursor/rules/branding.mdc, CONTRIBUTING.md update)

Made with [Cursor](https://cursor.com)
