### PR TITLE
fix: make xsrf cookie Secure conditional on HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ The simplest way to deploy AUP Learning Cloud on a single machine in a developme
 - **Docker**: Install Docker and configure for non-root access
 
 ```bash
+# Install OEM kernel for AMD Ryzen AI Halo hardware support (reboot required after install)
+sudo apt update && sudo apt install linux-image-6.14.0-1018-oem
+
 # Install Docker
 curl -fsSL https://get.docker.com | sh
 

--- a/runtime/hub/core/jupyterhub_config.py
+++ b/runtime/hub/core/jupyterhub_config.py
@@ -124,13 +124,29 @@ c.JupyterHub.tornado_settings = _BASE_TORNADO_SETTINGS
 # JupyterHub.cookie_options only affects Hub session cookies; the _xsrf cookie
 # is managed directly by Tornado and requires xsrf_cookie_kwargs in
 # tornado_settings to set Secure and SameSite.
-# - Secure: safe because HSTS is enforced site-wide via Cloudflare.
-# - SameSite=Lax: blocks cross-site POST CSRF while allowing OAuth top-level redirects.
-# - HttpOnly is intentionally omitted: JupyterHub's frontend JS must read _xsrf
-#   to include it in form submissions.
+#
+# Secure is conditional: browsers reject Secure cookies received over HTTP
+# (RFC 6265 §5.4) for non-loopback origins, which would break POST /hub/spawn
+# on the default `auplc-installer install` (NodePort + HTTP). Set Secure only
+# when the public origin actually uses HTTPS:
+#   - proxy.https.enabled=true   -> chart terminates TLS itself (autohttps)
+#   - custom.security.publicScheme="https" -> opt-in for external TLS
+#     terminators (Cloudflare tunnel, external HTTPS ingress / LB)
+# SameSite=Lax is always safe and blocks cross-site POST CSRF while still
+# allowing OAuth top-level redirects.
+# HttpOnly is intentionally omitted: JupyterHub's frontend JS must read
+# _xsrf to include it in form submissions.
+_proxy_https_enabled = bool(z2jh.get_config("proxy.https.enabled", False))
+_public_scheme = str(z2jh.get_config("custom.security.publicScheme") or "").strip().lower()
+_use_secure_cookies = _proxy_https_enabled or _public_scheme == "https"
+
+_xsrf_cookie_kwargs: dict = {"samesite": "Lax"}
+if _use_secure_cookies:
+    _xsrf_cookie_kwargs["secure"] = True
+
 c.JupyterHub.tornado_settings = {
     **c.JupyterHub.tornado_settings,
-    "xsrf_cookie_kwargs": {"secure": True, "samesite": "Lax"},
+    "xsrf_cookie_kwargs": _xsrf_cookie_kwargs,
 }
 
 # Inject platform identity into every Jinja template context so that

--- a/runtime/values.yaml
+++ b/runtime/values.yaml
@@ -69,6 +69,18 @@ custom:
     allowedOrigins: []
 
   # ============================================================================
+  # Public Scheme (TLS termination outside the chart)
+  # ============================================================================
+  # When TLS is terminated by an external component (Cloudflare tunnel,
+  # external ingress / HTTPS load balancer) instead of the chart's autohttps
+  # (proxy.https.enabled=true), set publicScheme="https" so the Hub marks the
+  # _xsrf cookie Secure. Leave unset (or "http") for the default single-node
+  # HTTP install — browsers reject Secure cookies received over HTTP and
+  # POST /hub/spawn would 403 (see AUPPM-64).
+  # security:
+  #   publicScheme: "https"
+
+  # ============================================================================
   # Git Repository Cloning
   # ============================================================================
   # Users can provide an optional Git URL on the spawn form; the repo will be


### PR DESCRIPTION
## Summary

Fixes [AUPPM-64](https://amd.atlassian.net/browse/AUPPM-64) by making the `_xsrf` cookie's `Secure` flag conditional on the public HTTPS topology instead of always setting it.

## Changes

- Keep `SameSite=Lax` on `_xsrf` for all deployments, but only set `Secure` when `proxy.https.enabled=true` or `custom.security.publicScheme="https"`.
- Document the `custom.security.publicScheme` opt-in for external TLS terminators such as Cloudflare tunnels or external HTTPS load balancers.
- Document the OEM kernel prerequisite for AMD Ryzen AI Halo hardware support in the quick-start README.

## Testing

- [x] Parsed `runtime/hub/core/jupyterhub_config.py` with Python `ast.parse`.
- [x] Parsed `runtime/values.yaml` with PyYAML.
- [x] Built and rolled out the Hub image on the local Kubernetes cluster.
- [x] Verified running pod image contains the same `jupyterhub_config.py` bytes as the repo and image.
- [x] Verified HTTP `_xsrf` `Set-Cookie` header is `Path=/hub/; SameSite=Lax` without `Secure`.
- [x] Verified `/hub/spawn` proceeds past XSRF into server spawn (`302 POST /hub/spawn -> /hub/spawn-pending/...`).

## Files Changed

- `runtime/hub/core/jupyterhub_config.py`
- `runtime/values.yaml`
- `README.md`

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Tested on local Kubernetes cluster
- [x] Documentation links updated

Made with [Cursor](https://cursor.com)