### PR TITLE
fix(home): address onboarding review feedback

### DIFF
--- a/runtime/hub/frontend/apps/home/src/App.tsx
+++ b/runtime/hub/frontend/apps/home/src/App.tsx
@@ -699,15 +699,6 @@ function App() {
         </section>
       </div>
 
-      {/* Footer */}
-      <div className="home-footer">
-        <div className="container">
-          &copy; 2025–2026 Advanced Micro Devices, Inc. All rights reserved.
-          &middot;
-          {PLATFORM_NAME}
-        </div>
-      </div>
-
       {/* Stop Server Confirm Modal */}
       {/* Stop Server Confirm Modal */}
       {showStopConfirm && (

--- a/runtime/hub/frontend/apps/home/src/styles.css
+++ b/runtime/hub/frontend/apps/home/src/styles.css
@@ -718,16 +718,6 @@
   margin: 0;
 }
 
-/* ---- Footer ---- */
-.home-footer {
-  border-top: 1px solid var(--home-border);
-  padding: 1.5rem 0;
-  text-align: center;
-  font-size: 0.78rem;
-  color: var(--home-text-muted);
-  margin-top: 1rem;
-}
-
 /* ---- Confirm Modal ---- */
 .confirm-overlay {
   position: fixed;
@@ -953,7 +943,10 @@
   padding: 1.5rem;
 }
 .onboarding-modal {
-  width: min(1040px, 100%);
+  width: min(1040px, calc(100vw - 3rem));
+  max-height: min(760px, calc(100vh - 3rem));
+  display: flex;
+  flex-direction: column;
   background: var(--home-surface-0);
   color: var(--home-text);
   border: 1px solid var(--home-border);
@@ -1007,13 +1000,22 @@
   transform: scale(1.02);
 }
 .onboarding-modal-body {
+  flex: 1 1 auto;
+  min-height: clamp(440px, 58vh, 560px);
+  overflow-y: auto;
   padding: 1.5rem;
 }
 .onboarding-step-layout {
+  min-height: 100%;
   display: grid;
   grid-template-columns: minmax(0, 0.95fr) minmax(420px, 1.15fr);
   gap: 1.25rem;
   align-items: stretch;
+}
+.onboarding-panel-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 .onboarding-panel-copy h2 {
   font-family: 'Plus Jakarta Sans', sans-serif;
@@ -1312,8 +1314,18 @@
 /* ---- Responsive ---- */
 @media (max-width: 900px) {
   .resources-grid { grid-template-columns: repeat(2, 1fr); }
+  .onboarding-modal {
+    max-height: calc(100vh - 2rem);
+  }
+  .onboarding-modal-body {
+    min-height: 0;
+  }
   .onboarding-step-layout {
     grid-template-columns: 1fr;
+    min-height: auto;
+  }
+  .onboarding-panel-copy {
+    justify-content: flex-start;
   }
 }
 @media (max-width: 768px) {
@@ -1342,10 +1354,13 @@
     overflow-y: auto;
   }
   .onboarding-modal {
+    width: 100%;
+    max-height: none;
     margin-top: 1rem;
   }
   .onboarding-modal-body {
     padding: 1.25rem;
+    overflow: visible;
   }
   .onboarding-panel-copy h2 {
     font-size: 1.55rem;


### PR DESCRIPTION
## Summary

Addresses follow-up review feedback for the Home onboarding guide merged in PR #87 by making the guide modal feel consistent across pages and removing duplicated footer attribution from the React Home app.

## Changes

- Removed the Home app's local copyright/platform footer so the global `#auplc-powered-by-footer` remains the single footer source.
- Gave the onboarding modal a consistent responsive shell with a shared body height on desktop.
- Added modal/body overflow behavior so narrow screens can scroll naturally without changing the desktop page size.
- Centered onboarding copy vertically on desktop and reset it to top-aligned content on smaller screens.

## Testing

- [x] `pnpm --filter @auplc/home run lint`
- [x] `pnpm --filter @auplc/home run build`
- [x] LSP diagnostics clean for `runtime/hub/frontend/apps/home/src/App.tsx`
- [x] Confirmed no `home-footer`/duplicate React footer markup remains in Home app source

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are scoped to Home onboarding review feedback
- [x] Global AUP Learning Cloud footer attribution remains preserved in `runtime/hub/frontend/templates/page.html`