### PR TITLE
Sync docs with current platform behavior

### DIFF
--- a/source/installation/multi-node.md
+++ b/source/installation/multi-node.md
@@ -80,17 +80,11 @@ Verify labels:
 kubectl describe node <node-name> | grep amd.com/gpu
 ```
 
-### About `node-type` Labels
+### About Accelerator Selectors
 
-The single-node installer now relies on the ROCm labeller and generated selectors such as `amd.com/gpu.product-name`.
+The sample file `runtime/values-multi-nodes.yaml.example` now follows `runtime/values.yaml` and uses ROCm labeller keys such as `amd.com/gpu.product-name` directly.
 
-For multi-node deployments, the sample file `runtime/values-multi-nodes.yaml.example` still uses legacy `node-type` labels for administrator-controlled placement. If you use that sample file unchanged, you must label nodes manually:
-
-```bash
-kubectl label nodes <NODE_NAME> node-type=strix-halo
-```
-
-That legacy label model is a multi-node sample-file convention, not the canonical single-node behavior.
+That means multi-node deployments should rely on the device plugin plus labeller output, not on a separate manual `node-type` labelling convention.
 
 ## 4. Storage
 

--- a/source/installation/multi-node.md
+++ b/source/installation/multi-node.md
@@ -1,517 +1,157 @@
 # Multi-Node Cluster Deployment
 
-This guide provides instructions for deploying AUP Learning Cloud on a multi-node Kubernetes cluster using Ansible. This deployment is suitable for production environments requiring high availability and scalability.
+This guide covers the current Ansible + Helm workflow for deploying AUP Learning Cloud on a multi-node K3s cluster.
 
-## Overview
+Unlike the single-node path, multi-node deployment is not driven by `./auplc-installer install`. The main flow is:
 
-Multi-node deployment provides:
-- **High Availability**: Redundancy across multiple nodes
-- **Scalability**: Distribute workload across cluster
-- **Resource Isolation**: Separate control plane and worker nodes
-- **Production Ready**: Suitable for production environments
-
-## Architecture
-
-A typical multi-node setup consists of:
-- **Control Plane Nodes** (1-3 nodes): Run Kubernetes control plane components
-- **Worker Nodes** (2+ nodes): Run user workloads and JupyterHub services
-- **Storage Node** (optional): Dedicated NFS storage server
+1. build the cluster with Ansible
+2. prepare the multi-node values file
+3. deploy the chart with Helm
 
 ## Prerequisites
 
-### Hardware Requirements
+### Controller / Ansible Host
 
-**Per Node**:
-- AMD Ryzen™ AI Halo Device (or compatible AMD hardware)
-- 32GB+ RAM (64GB recommended for worker nodes)
-- 500GB+ SSD (1TB+ for storage nodes)
-- 1Gbps+ network connectivity
-
-**Recommended Cluster**:
-- 1 control plane node
-- 3+ worker nodes
-- 1 dedicated NFS storage node (optional)
-
-### Software Requirements
-
-**All Nodes**:
-- Ubuntu 24.04.3 LTS
-- SSH access configured
-- Root/sudo privileges
-
-**Control Node** (Ansible runner):
-- Ansible 2.9 or later
+- Ansible available
 - SSH key access to all nodes
-- Python 3.8+
+- ability to connect as `root` or the configured `ansible_user`
 
-### Network Requirements
+### Cluster Nodes
 
-- All nodes must be on the same network or have connectivity
-- Fixed IP addresses or DHCP with MAC reservation
-- Firewall rules configured for Kubernetes ports
+- Ubuntu 24.04
+- consistent hostname resolution across the fleet
+- AMD GPU-capable nodes if you want accelerator-backed resources
 
-## Installation Steps
+Current inventory defaults are defined in `deploy/ansible/inventory.yml`, including the pinned `k3s_version`.
 
-### 1. Prepare Control Node
+## 1. Configure Inventory
 
-Install Ansible on your control machine:
-
-```bash
-# Install Ansible
-sudo apt update
-sudo apt install ansible python3-pip
-
-# Verify installation
-ansible --version
-```
-
-### 2. Configure SSH Access
-
-Set up passwordless SSH access to all nodes:
+Edit the Ansible inventory:
 
 ```bash
-# Generate SSH key (if not already exists)
-ssh-keygen -t rsa -b 4096
-
-# Copy SSH key to all nodes
-ssh-copy-id user@node1
-ssh-copy-id user@node2
-ssh-copy-id user@node3
-# ... for all nodes
-
-# Test SSH access
-ssh user@node1 "hostname"
+cd deploy/ansible
+nano inventory.yml
 ```
 
-### 3. Clone Repository
+Key items to set:
 
-```bash
-git clone https://github.com/AMDResearch/aup-learning-cloud.git
-cd aup-learning-cloud/deploy/ansible
-```
+- server and agent hostnames
+- `ansible_user`
+- cluster token
+- `api_endpoint`
 
-### 4. Configure Inventory
-
-Edit `deploy/ansible/inventory.yml` with your cluster node information. The `server` is the control-plane node (also the Ansible control host); `agent` entries are the worker nodes:
-
-```yaml
----
-k3s_cluster:
-  children:
-    server:
-      hosts:
-        <YOUR-SERVER-HOSTNAME>:
-    agent:
-      hosts:
-        <YOUR-AGENT-HOSTNAME-1>:
-        <YOUR-AGENT-HOSTNAME-2>:
-        <YOUR-AGENT-HOSTNAME-3>:
-
-  vars:
-    ansible_port: 22
-    ansible_user: root
-    k3s_version: v1.32.3+k3s1
-    # Generate a random token:  openssl rand -base64 64
-    token: "changeme!"
-    api_endpoint: "{{ hostvars[groups['server'][0]]['ansible_host'] | default(groups['server'][0]) }}"
-```
-
-> **Important**: All nodes must have consistent `/etc/hosts` entries so they can resolve each other by hostname. The server node must also have root SSH key access to all agent nodes. See `deploy/scripts/setup_ssh_root_access.sh` for a helper script.
-
-### 5. Run Base Setup
-
-Install basic requirements on all nodes:
+## 2. Build The Cluster
 
 ```bash
 cd deploy/ansible
 
-# Install base packages and configure hosts
+# Base OS / package preparation
 sudo ansible-playbook playbooks/pb-base.yml
 
 # Deploy K3s cluster
 sudo ansible-playbook playbooks/pb-k3s-site.yml
-```
 
-### 6. Install GPU / NPU Drivers
-
-Install ROCm on all GPU nodes:
-
-```bash
+# Install ROCm on accelerator nodes
 sudo ansible-playbook playbooks/pb-rocm.yml
 ```
 
-Verify GPU detection:
+Useful related playbooks:
 
 ```bash
-rocminfo
-rocm-smi
+# Upgrade cluster
+sudo ansible-playbook playbooks/pb-k3s-upgrade.yml
+
+# Reset cluster
+sudo ansible-playbook playbooks/pb-k3s-reset.yml
 ```
 
-**Official documentation**: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html
+## 3. GPU Device Plugin And Labels
 
-### 7. Install Helm and K9s
-
-```bash
-# Install Helm
-wget https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz -O /tmp/helm-linux-amd64.tar.gz
-cd /tmp && tar -zxvf helm-linux-amd64.tar.gz
-sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm
-rm /tmp/helm-linux-amd64.tar.gz
-
-# Install K9s (optional but recommended)
-wget https://github.com/derailed/k9s/releases/latest/download/k9s_linux_amd64.deb
-sudo apt install ./k9s_linux_amd64.deb
-rm k9s_linux_amd64.deb
-```
-
-### 8. Deploy GPU Device Plugin and Label Nodes
-
-Deploy the AMD GPU Kubernetes device plugin:
+For manual cluster setup, deploy the ROCm device plugin and node labeller:
 
 ```bash
 kubectl create -f https://raw.githubusercontent.com/ROCm/k8s-device-plugin/master/k8s-ds-amdgpu-dp.yaml
+kubectl create -f https://raw.githubusercontent.com/ROCm/k8s-device-plugin/master/k8s-ds-amdgpu-labeller.yaml
 ```
 
-Verify GPU is detected:
+Verify labels:
 
 ```bash
 kubectl describe node <node-name> | grep amd.com/gpu
 ```
 
-Label each node based on GPU architecture:
+### About `node-type` Labels
+
+The single-node installer now relies on the ROCm labeller and generated selectors such as `amd.com/gpu.product-name`.
+
+For multi-node deployments, the sample file `runtime/values-multi-nodes.yaml.example` still uses legacy `node-type` labels for administrator-controlled placement. If you use that sample file unchanged, you must label nodes manually:
 
 ```bash
-# Label nodes by GPU type
-kubectl label nodes <NODE_NAME> node-type=<TYPE>
+kubectl label nodes <NODE_NAME> node-type=strix-halo
 ```
 
-| Node Group | node-type Label | Hardware Description |
-| ---------- | --------------- | -------------------- |
-| phx        | `phx`           | Phoenix (AMD 7940HS / 7640HS) |
-| dgpu       | `dgpu`          | Discrete GPU (Radeon 7900XTX, 9070XT, W9700) |
-| strix      | `strix`         | Strix (AMD AI 370 / 350) |
-| strix-halo | `strix-halo`    | Strix-Halo (AMD AI MAX 395) |
+That legacy label model is a multi-node sample-file convention, not the canonical single-node behavior.
 
-Verify labels:
+## 4. Storage
 
-```bash
-kubectl get nodes --show-labels | grep node-type
-```
+Multi-node deployments usually need a shared storage class. The example values file assumes `nfs-client`.
 
-### 9. Configure NFS Storage
-
-#### Set up the NFS Server
-
-On the controller node (or a dedicated storage node):
-
-```bash
-# Install NFS server
-sudo apt install nfs-kernel-server
-
-# Create NFS share
-sudo mkdir -p /nfs
-sudo chown -R nobody:nogroup /nfs
-sudo chmod 777 /nfs
-
-# Configure exports
-echo "/nfs <Your-Subnet/24>(rw,sync,no_subtree_check,no_root_squash,insecure)" | sudo tee -a /etc/exports
-
-# Restart NFS server
-sudo systemctl restart nfs-kernel-server
-```
-
-Install NFS client on all agent nodes (the `pb-base.yml` playbook does this automatically):
-
-```bash
-sudo apt install nfs-common
-```
-
-#### Deploy NFS Provisioner
+If you use the included NFS provisioner example:
 
 ```bash
 helm repo add nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
 helm repo update
 
 helm install nfs-subdir-external-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
-    --namespace nfs-provisioner \
-    --create-namespace \
-    -f deploy/k8s/nfs-provisioner/values.yaml
+  --namespace nfs-provisioner \
+  --create-namespace \
+  -f deploy/k8s/nfs-provisioner/values.yaml
 ```
 
-Set as default StorageClass:
+## 5. Prepare The Multi-Node Values File
 
-```bash
-kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-kubectl get storageclass
-```
-
-### 10. Build and Import Images
-
-**Option A: Use a container registry** (recommended for production):
-
-```bash
-# Build images from repo root
-cd /path/to/aup-learning-cloud
-sudo ./auplc-installer img build
-
-# Push to registry
-docker push ghcr.io/amdresearch/auplc-hub:latest
-docker push ghcr.io/amdresearch/auplc-cv:latest
-# ... for all images
-```
-
-**Option B: Import images directly to nodes** (air-gapped environments):
-
-```bash
-# Save images to tar files
-docker save ghcr.io/amdresearch/auplc-dl:latest -o auplc-dl.tar
-
-# Copy and import to cluster nodes (K3s uses containerd)
-ansible workers -m copy -a "src=auplc-dl.tar dest=/tmp/"
-ansible workers -m shell -a "k3s ctr images import /tmp/auplc-dl.tar"
-```
-
-### 11. Configure JupyterHub
-
-The multi-node template is a **standalone** configuration file that already includes all required settings (accelerators, courses, teams, storage, network, etc.). Copy it and customize for your environment — no need to layer it on top of `values.yaml`:
+The repository includes a standalone example file for multi-node deployments:
 
 ```bash
 cd runtime
-
-# Copy multi-node configuration template
 cp values-multi-nodes.yaml.example values-multi-nodes.yaml
 nano values-multi-nodes.yaml
 ```
 
-Key settings to customize:
-- **Storage class**: `nfs-client` (already set for multi-node)
-- **Ingress**: Configure your domain in the `ingress` section
-- **Authentication**: Fill in GitHub App credentials in `hub.config.GitHubOAuthenticator`
-- **Images**: Update `custom.resources.images` with your registry/org
-- **Admin**: Set `admin_users` and `githubOrgName`
+Review at least these sections:
 
-See [Configuration Reference](../jupyterhub/configuration-reference.md) for all available options.
+- `custom.authMode`
+- `custom.githubOrgName`
+- `custom.accelerators`
+- `custom.resources.images`
+- `custom.resources.requirements`
+- `custom.teams.mapping`
+- `hub.config.GitHubOAuthenticator`
+- `hub.db.pvc.storageClassName`
+- `singleuser.storage.dynamic.storageClass`
+- `proxy.service`
+- `ingress`
 
-### 12. Deploy JupyterHub
+## 6. Deploy JupyterHub
 
 ```bash
 cd runtime
-
-# Deploy using the multi-node config directly
 helm upgrade --install jupyterhub ./chart \
   -n jupyterhub --create-namespace \
   -f values-multi-nodes.yaml
 ```
 
-### 13. Verify Deployment
+## 7. Verify Deployment
 
 ```bash
-# Get kubeconfig from control plane node
-scp user@master1:~/.kube/config ~/.kube/config
-
-# Check nodes
 kubectl get nodes
-
-# Check all pods
 kubectl get pods -n jupyterhub
-
-# Check storage
 kubectl get pvc -n jupyterhub
-kubectl get storageclass
-```
-
-## Access JupyterHub
-
-Configure ingress for domain-based access:
-
-```bash
-# Check ingress
 kubectl get ingress -n jupyterhub
-
-# Access via domain
-https://your-domain.com
 ```
 
-## High Availability Configuration
+## Notes On Scope
 
-For production high availability:
-
-1. **Multiple Control Plane Nodes** (3 recommended):
-   - Edit inventory to include multiple control plane nodes
-   - K3s will automatically configure HA etcd
-
-2. **Load Balancer**:
-   - Use external load balancer for control plane
-   - Configure in K3s server installation
-
-3. **Multiple Hub Replicas**:
-   ```yaml
-   hub:
-     replicas: 2
-     db:
-       type: postgres  # Use external database
-   ```
-
-## Monitoring and Maintenance
-
-### Check Cluster Health
-
-```bash
-# Node status
-kubectl get nodes
-
-# Pod status across namespaces
-kubectl get pods -A
-
-# Resource usage
-kubectl top nodes
-kubectl top pods -n jupyterhub
-```
-
-### Upgrade Cluster
-
-```bash
-cd deploy/ansible
-
-# Upgrade K3s
-ansible-playbook playbooks/pb-k3s-upgrade.yml
-
-# Upgrade JupyterHub (from repo root)
-cd /path/to/aup-learning-cloud
-bash scripts/helm_upgrade.bash
-```
-
-### Backup and Restore
-
-Back up the hub database PVC and NFS storage (if used) before major upgrades. Backup and monitoring guides will be added in a future release.
-
-## Troubleshooting
-
-### kubectl permission denied error
-
-If you encounter errors like:
-```
-error: error loading config file "/etc/rancher/k3s/k3s.yaml": open /etc/rancher/k3s/k3s.yaml: permission denied
-```
-
-**Solution**:
-Add the following to your `inventory.yml` before running the playbook:
-```yaml
-k3s_cluster:
-  vars:
-    extra_server_args: "--write-kubeconfig-mode=644"
-```
-
-Or manually copy the config:
-```bash
-mkdir -p ~/.kube
-sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-sudo chown $(id -u):$(id -g) ~/.kube/config
-```
-
-See [K3s Cluster Access](https://docs.k3s.io/cluster-access) for official documentation.
-
-### Helm command not found
-
-If `helm` command is not found, verify the installation:
-```bash
-# Check if helm is in PATH
-which helm
-
-# If not, ensure /usr/local/bin is in PATH
-echo $PATH
-
-# Reinstall helm if needed (see Step 2 above)
-```
-
-### Ansible halts at "Enable and check K3s service"
-
-Check if the K3s agent service is running on the problematic node:
-
-```bash
-ssh <agent_node>
-sudo systemctl status k3s-agent.service
-```
-
-If the service is running but shows connection errors to the server, verify that `/etc/hosts` on the agent node resolves the server hostname correctly.
-
-### Node Not Joining Cluster
-
-```bash
-# Check K3s service on problem node
-ssh <node> "systemctl status k3s-agent"
-
-# Check K3s logs
-ssh <node> "journalctl -u k3s-agent -n 100"
-
-# Verify network connectivity
-ssh <node> "ping <server-hostname>"
-```
-
-### Storage Issues
-
-```bash
-# Check NFS mount
-kubectl exec -it <pod-name> -n jupyterhub -- df -h
-
-# Check NFS provisioner logs
-kubectl logs -n kube-system -l app=nfs-provisioner
-```
-
-### Networking Issues
-
-```bash
-# Check CNI pods
-kubectl get pods -n kube-system
-
-# Test pod-to-pod networking
-kubectl run test-pod --image=busybox --rm -it -- ping <pod-ip>
-```
-
-## Scaling
-
-### Add Worker Nodes
-
-1. Add new hostnames to the `agent` section in `deploy/ansible/inventory.yml`
-2. Run the K3s playbook:
-   ```bash
-   cd deploy/ansible
-   sudo ansible-playbook playbooks/pb-k3s-site.yml
-   ```
-
-### Remove Worker Nodes
-
-```bash
-# Drain node
-kubectl drain <node-name> --ignore-daemonsets --delete-emptydir-data
-
-# Delete from cluster
-kubectl delete node <node-name>
-
-# Uninstall K3s on the node
-ssh <node-name> "/usr/local/bin/k3s-agent-uninstall.sh"
-```
-
-### Reset Cluster
-
-To reset the entire K3s cluster (all data and config will be removed):
-
-```bash
-cd deploy/ansible
-sudo ansible-playbook playbooks/pb-k3s-reset.yml
-```
-
-To reset a single node only:
-
-```bash
-sudo ansible-playbook playbooks/pb-k3s-reset.yml --limit <node_name>
-```
-
-After resetting, remove the `~/.kube` directory.
-
-## Next Steps
-
-- [Configure JupyterHub](../jupyterhub/index.md)
-- [Set up Authentication](../jupyterhub/authentication-guide.md)
-- [Manage Users](../jupyterhub/user-management.md)
-- [Configure Quotas](../jupyterhub/quota-system.md)
+- The sample multi-node values file is a starting point, not a promise that every advanced topology is turnkey.
+- High-availability choices such as external databases, multiple Hub replicas, or production ingress/TLS should be treated as explicit operator decisions on top of the base chart deployment.
+- If you want the simplest local install, use the single-node installer flow instead of this guide.

--- a/source/installation/quick-start.md
+++ b/source/installation/quick-start.md
@@ -1,80 +1,75 @@
 # Quick Start
 
-The simplest way to deploy AUP Learning Cloud on a single machine in a development or demo environment.
+This is the shortest path to a local single-node AUP Learning Cloud deployment.
 
 ## Prerequisites
 
-- **Hardware**: Supported AMD GPU or APU — select your device in the Installation section below. Examples:
-  - **Radeon PRO**: AI PRO R9700/R9600D
-  - **Radeon**: RX 9070/9060 series
-  - **Ryzen AI**: Max+ PRO 395, Max PRO 390/385/380, Max+ 395, Max 390/385, 9 HX 375/370, 9 365
-- **Memory**: 32GB+ RAM (64GB recommended)
-- **Storage**: 500GB+ SSD
-- **OS**: Ubuntu 24.04.3 LTS
-- **Docker**: Install Docker and configure for non-root access (see below; skip if already installed)
+- Ubuntu 24.04
+- sudo access
+- Docker available for the default install path
+- an AMD GPU supported by the installer auto-detection or an explicit `--gpu=...` override
 
-### Package dependencies
-
-Install build tools (required for building container images):
+Install the basic host dependency:
 
 ```bash
 sudo apt install build-essential
 ```
 
-### Install Docker
-
-:::{dropdown} Install Docker — skip if already installed
-:animate: fade-in
-
-If Docker is already installed and your user is in the `docker` group, skip this section.
+If Docker is not installed yet:
 
 ```bash
-# Install Docker
 curl -fsSL https://get.docker.com | sh
-
-# Add current user to docker group
 sudo usermod -aG docker $USER
-
-# Apply group changes without logout (or logout/login instead)
 newgrp docker
-
-# Verify installation
 docker --version
 ```
 
-See [Docker Post-installation Steps](https://docs.docker.com/engine/install/linux-postinstall/) and [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/) for details.
+## Install
 
+Clone the repository and run the installer from the repo root:
 
-:::
-
-## Installation
-
-Select your AMD device family and GPU below. The install commands update to use the correct **GPU_TYPE** for your selection.
-
-```{eval-rst}
-.. include:: includes/selector-quickstart-gpu.rst
+```bash
+git clone https://github.com/AMDResearch/aup-learning-cloud.git
+cd aup-learning-cloud
+sudo ./auplc-installer install
 ```
 
-After installation completes, open <http://localhost:30890> in your browser. No login credentials are required — you will be automatically logged in.
+After installation completes, open <http://localhost:30890>.
+
+The checked-in default values in this repository use:
+
+- `custom.authMode: auto-login`
+- `proxy.service.type: NodePort`
+- `proxy.service.nodePorts.http: 30890`
+- `local-path` storage
+
+So the default local experience is a simple HTTP NodePort deployment.
+
+## Common Variants
+
+```bash
+# Pull prebuilt images instead of building locally
+sudo ./auplc-installer install --pull
+
+# Force a specific GPU family / target
+sudo ./auplc-installer install --gpu=strix-halo
+
+# Use containerd mode for more portable/offline-oriented operation
+sudo ./auplc-installer install --docker=0
+
+# Use registry and package mirrors
+sudo ./auplc-installer install \
+  --mirror=mirror.example.com \
+  --mirror-pip=https://pypi.tuna.tsinghua.edu.cn/simple
+```
 
 ## Uninstall
-
-To remove all components (K3s, JupyterHub, and related resources):
 
 ```bash
 sudo ./auplc-installer uninstall
 ```
 
-:::{seealso}
-For all other commands (upgrade, runtime-only install/remove, image build/pull, mirror configuration, etc.), see the [Single-Node Deployment](single-node.md) guide.
-:::
-
 ## Next Steps
 
-After installation:
-
-1. Access JupyterHub at <http://localhost:30890>
-2. Review the [JupyterHub Configuration](../jupyterhub/index.md) guide
-3. Set up [Authentication](../jupyterhub/authentication-guide.md) if needed
-4. Configure [User Management](../jupyterhub/user-management.md) for your environment
-5. Explore the available learning toolkits
+- For all installer subcommands and runtime workflows, see [Single-Node Deployment](single-node.md)
+- For auth and resource configuration, see [JupyterHub Configuration](../jupyterhub/index.md)

--- a/source/installation/single-node.md
+++ b/source/installation/single-node.md
@@ -1,269 +1,191 @@
 # Single-Node Deployment
 
-This guide describes single-node deployment of AUP Learning Cloud using the **auplc-installer** script on the **develop** branch. This deployment is suitable for development, testing, and demo environments.
+This guide covers the current single-node workflow driven by `./auplc-installer`.
 
 :::{seealso}
-For the shortest path, see the [Quick Start](quick-start.md) guide.
+For the shortest path, see [Quick Start](quick-start.md).
 :::
+
+## What The Installer Does
+
+`./auplc-installer install` is the canonical workstation deployment path. It can:
+
+- detect supported AMD GPU families and SKUs
+- install K3s and supporting tools
+- deploy the ROCm GPU device plugin and node labeller
+- generate a local values overlay
+- build or pull required images
+- deploy the Hub runtime from `runtime/chart`
 
 ## Prerequisites
 
-### Hardware Requirements
-
-- **Device**: Supported AMD GPU or APU — select your device in the Installation section below. Examples:
-  - **Radeon PRO**: AI PRO R9700/R9600D
-  - **Radeon**: RX 9070/9060 series
-  - **Ryzen AI**: Max+ PRO 395, Max PRO 390/385/380, Max+ 395, Max 390/385, 9 HX 375/370, 9 365
-- **Memory**: 32GB+ RAM (64GB recommended for production-like testing)
-- **Storage**: 500GB+ SSD
-- **Network**: Stable internet connection for downloading images
-
-### Software Requirements
-
-- **Operating System**: Ubuntu 24.04.3 LTS
-- **Docker**: Version 20.10 or later (required when using default Docker-as-runtime mode)
-- **Root/Sudo Access**: Required to run the installer
-
-## Installation with auplc-installer
-
-On the **develop** branch, single-node installation is done with the **auplc-installer** script at the repository root.
-
-### 1. Package dependency
-
-Install build tools (required for building container images):
+- Ubuntu 24.04
+- sudo access
+- Docker installed if you are using the default Docker-backed runtime path
+- `build-essential`
 
 ```bash
 sudo apt install build-essential
 ```
 
-### 2. Install Docker
-
-By default, Docker is used as the K3s container runtime (backend).
-
-:::{dropdown} Install Docker — skip if already installed
-:animate: fade-in
-
-If Docker is already installed and your user is in the `docker` group, skip this section.
+Optional Docker installation:
 
 ```bash
-# Install Docker
 curl -fsSL https://get.docker.com | sh
-
-# Add current user to docker group
 sudo usermod -aG docker $USER
-
-# Apply group changes (or logout/login)
 newgrp docker
-
-# Verify installation
 docker --version
 ```
 
-See [Docker Post-installation Steps](https://docs.docker.com/engine/install/linux-postinstall/) for detailed configuration.
-
-:::
-
-### 3. Clone the repository and run the installer
-
-Select your AMD device family and GPU below. The install commands update to use the correct **GPU_TYPE** for your selection.
-
-```{eval-rst}
-.. include:: includes/selector-quickstart-gpu.rst
-```
-
-After installation completes, open <http://localhost:30890> in your browser. The default uses **auto-login** — no credentials required.
-
-### 4. auplc-installer commands
-
-| Command | Description |
-|---------|-------------|
-| `install` | Full installation (K3s, tools, GPU plugin, images, JupyterHub) |
-| `uninstall` | Remove K3s and all components |
-| `install-tools` | Install Helm and K9s only |
-| `rt install` | Deploy JupyterHub runtime only |
-| `rt upgrade` | Upgrade JupyterHub (e.g. after editing `runtime/values.yaml`) |
-| `rt remove` | Remove JupyterHub runtime only |
-| `rt reinstall` | Remove and reinstall JupyterHub (e.g. after image changes) |
-| `img build` | Build all custom container images |
-| `img build [target...]` | Build specific images (e.g. `img build hub`, `img build hub cv`) |
-| `img pull` | Pull external images for offline use |
-
-Legacy long-form commands are still supported: `install-runtime`, `remove-runtime`, `upgrade-runtime`, `build-images`, `pull-images`.
-
-**Examples:**
+## Standard Install
 
 ```bash
-# Upgrade JupyterHub after changing runtime/values.yaml
+git clone https://github.com/AMDResearch/aup-learning-cloud.git
+cd aup-learning-cloud
+sudo ./auplc-installer install
+```
+
+After installation, access the Hub at <http://localhost:30890>.
+
+## Important Defaults In This Repository
+
+The current checked-in `runtime/values.yaml` is oriented to simple local deployment:
+
+- `custom.authMode: auto-login`
+- `custom.adminUser.enabled: false`
+- `hub.db.pvc.storageClassName: local-path`
+- `singleuser.storage.dynamic.storageClass: local-path`
+- `proxy.service.type: NodePort`
+- `proxy.service.nodePorts.http: 30890`
+- `ingress.enabled: false`
+- `prePuller.hook.enabled: false`
+- `prePuller.continuous.enabled: false`
+
+That means NFS, ingress, TLS, and auto-created admin credentials are optional configuration choices, not default behavior.
+
+## Installer Command Matrix
+
+### Core Lifecycle
+
+```bash
+sudo ./auplc-installer install
+sudo ./auplc-installer uninstall
+sudo ./auplc-installer detect-gpu
+sudo ./auplc-installer install-tools
+```
+
+### Runtime Lifecycle
+
+```bash
+sudo ./auplc-installer rt install
 sudo ./auplc-installer rt upgrade
-
-# Rebuild images and reinstall runtime after Dockerfile changes
-sudo ./auplc-installer img build
+sudo ./auplc-installer rt remove
 sudo ./auplc-installer rt reinstall
-
-# Show all options
-./auplc-installer help
 ```
 
-### 5. Runtime and mirror configuration
-
-The installer supports `--flag=value` options (or equivalent environment variables):
-
-| Flag | Env variable | Default | Description |
-|---|---|---|---|
-| `--gpu=TYPE` | `GPU_TYPE` | auto-detect | GPU type: `phx`, `strix`, `strix-halo`, `rdna4` |
-| `--docker=0\|1` | `K3S_USE_DOCKER` | `1` | Container runtime: `1` = Docker, `0` = containerd |
-| `--mirror=HOST` | `MIRROR_PREFIX` | — | Registry mirror host (e.g. `mirror.example.com`) |
-| `--mirror-pip=URL` | `MIRROR_PIP` | — | PyPI mirror URL |
-| `--mirror-npm=URL` | `MIRROR_NPM` | — | npm registry URL |
-
-Examples:
+### Image Lifecycle
 
 ```bash
-# Specify GPU type explicitly
+sudo ./auplc-installer img build
+sudo ./auplc-installer img build hub cv
+sudo ./auplc-installer img pull
+```
+
+### Development Workflow
+
+```bash
+sudo ./auplc-installer dev
+sudo ./auplc-installer dev deploy
+sudo ./auplc-installer dev upgrade
+sudo ./auplc-installer dev reinstall
+```
+
+## Common Install Flags
+
+```bash
+# Pull prebuilt custom images instead of building them locally
+sudo ./auplc-installer install --pull
+
+# Explicitly set GPU family / target
 sudo ./auplc-installer install --gpu=strix-halo
 
-# Use containerd runtime instead of Docker
+# Use containerd mode instead of Docker-backed mode
 sudo ./auplc-installer install --docker=0
 
-# Use registry and PyPI mirrors
-sudo ./auplc-installer install --mirror=mirror.example.com --mirror-pip=https://pypi.tuna.tsinghua.edu.cn/simple
-
-# Flags can be combined and placed anywhere
-sudo ./auplc-installer install --gpu=phx --docker=0 --mirror=mirror.example.com
+# Use registry / package mirrors
+sudo ./auplc-installer install \
+  --mirror=mirror.example.com \
+  --mirror-pip=https://pypi.example.com/simple \
+  --mirror-npm=https://registry.npmmirror.com
 ```
 
-**Docker mode** (default, `--docker=1`): images built with `make hub` are immediately visible to K3s after `rt upgrade`, no export needed. Requires Docker installed on the host.
+Supported install-time flags map to these environment variables:
 
-**containerd mode** (`--docker=0`): images are exported to K3s image directory for offline/portable deployments.
+| Flag | Environment Variable | Meaning |
+|------|----------------------|---------|
+| `--gpu=TYPE` | `GPU_TYPE` | Force GPU type / family |
+| `--docker=0\|1` | `K3S_USE_DOCKER` | Choose Docker or containerd path |
+| `--mirror=HOST` | `MIRROR_PREFIX` | Container registry mirror prefix |
+| `--mirror-pip=URL` | `MIRROR_PIP` | Python package mirror |
+| `--mirror-npm=URL` | `MIRROR_NPM` | npm registry mirror |
 
-### 6. Configure runtime (optional)
+## Offline And Portable Workflows
 
-To customize auth, images, storage, network, and other options, edit **`runtime/values.yaml`**. For all available settings and recommended workflow, see the [Configuration Reference: runtime/values.yaml](../jupyterhub/configuration-reference.md).
+### Containerd / Portable-Oriented Local Install
 
-After editing, run:
+```bash
+sudo ./auplc-installer install --docker=0
+```
+
+This path exports images into K3s image storage and is better suited for portable or partially disconnected use than the default Docker-backed path.
+
+### Offline Bundle Workflow
+
+Create an offline bundle on a connected machine:
+
+```bash
+./auplc-installer pack
+
+# Or build bundle from local images/artifacts
+./auplc-installer pack --local
+```
+
+Transfer the bundle to the target machine, unpack it, then run:
+
+```bash
+sudo ./auplc-installer install
+```
+
+The installer auto-detects the bundle via `manifest.json` and switches into offline mode.
+
+## Local Configuration Files
+
+- `runtime/values.yaml` - repository default deployment values
+- `runtime/values.local.yaml` - installer-generated local overlay
+
+The installer-generated overlay captures detected accelerator selectors and image tags for the local machine. Prefer editing `runtime/values.yaml` for intentional site configuration, then redeploy with:
 
 ```bash
 sudo ./auplc-installer rt upgrade
 ```
 
-### 7. Verify deployment
+## Verification
 
 ```bash
-# Check all pods are running
 kubectl get pods -n jupyterhub
-
-# Check services
 kubectl get svc -n jupyterhub
+kubectl get pvc -n jupyterhub
+```
 
-# Get admin credentials (if auto-admin is enabled)
+If you explicitly enabled admin bootstrap:
+
+```bash
 kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
-  -o go-template='{{index .data "admin-password" | base64decode}}'
+  -o jsonpath='{.data.admin-password}' | base64 -d && echo
 ```
 
-## Access JupyterHub
+## Troubleshooting Notes
 
-- **NodePort (default)**: <http://localhost:30890> or <http://node-ip:30890>
-- **Domain**: <https://your-domain.com> (if configured)
-
-## Post-Installation
-
-### Configure Authentication
-
-See [Authentication Guide](../jupyterhub/authentication-guide.md) to set up:
-- GitHub OAuth
-- Native Authenticator
-- User management
-
-### Configure Resource Quotas
-
-See [User Quota System](../jupyterhub/quota-system.md) to configure resource limits and tracking.
-
-### Manage Users
-
-See [User Management Guide](../jupyterhub/user-management.md) for batch user operations.
-
-## Troubleshooting
-
-### Pods Not Starting
-
-```bash
-# Check pod status
-kubectl describe pod <pod-name> -n jupyterhub
-
-# Check logs
-kubectl logs <pod-name> -n jupyterhub
-```
-
-### Image Pull Errors
-
-```bash
-# Check events
-kubectl get events -n jupyterhub
-
-# Verify images are available
-docker images | grep ghcr.io/amdresearch
-```
-
-### Connection Issues
-
-```bash
-# Check service status
-kubectl get svc -n jupyterhub
-
-# Check ingress (if using domain)
-kubectl get ingress -n jupyterhub
-```
-
-## Upgrading
-
-To upgrade JupyterHub after editing `runtime/values.yaml`:
-
-```bash
-sudo ./auplc-installer rt upgrade
-```
-
-To rebuild container images after changing Dockerfiles, then reinstall runtime:
-
-```bash
-sudo ./auplc-installer img build
-sudo ./auplc-installer rt reinstall
-```
-
-## Offline / Portable Operation
-
-The installer automatically configures the system for offline and portable operation. When you run `sudo ./auplc-installer install`, it:
-
-1. **Creates a dummy network interface** (`dummy0`) with a stable IP address (`10.255.255.1`)
-2. **Binds K3s to the dummy interface** using `--node-ip` and `--flannel-iface`
-3. **Pre-pulls all required container images** to local storage
-4. **Configures K3s to use local images** from `/var/lib/rancher/k3s/agent/images/`
-
-This ensures the cluster remains fully functional even when:
-- External network is disconnected (network cable unplugged)
-- WiFi network changes (connecting to different access points)
-- No network is available at all
-
-**How it works**: K3s is bound to a stable dummy interface IP instead of the physical network interface. This means K3s doesn't care about external network changes -- it always uses the same internal IP for cluster communication.
-
-**Reference**: [K3s Air-Gap Installation](https://docs.k3s.io/installation/airgap)
-
-## Uninstalling
-
-To remove JupyterHub runtime only (keeps K3s and other components):
-
-```bash
-sudo ./auplc-installer rt remove
-```
-
-To remove everything (K3s, JupyterHub, and installer-managed resources):
-
-```bash
-sudo ./auplc-installer uninstall
-```
-
-## Next Steps
-
-- [Configure JupyterHub](../jupyterhub/index.md)
-- [Set up Authentication](../jupyterhub/authentication-guide.md)
-- [Manage Users](../jupyterhub/user-management.md)
-- [Configure Quotas](../jupyterhub/quota-system.md)
+- If you changed `runtime/values.yaml`, use `sudo ./auplc-installer rt upgrade`.
+- If you changed container images or Dockerfiles, use `sudo ./auplc-installer img build` followed by `sudo ./auplc-installer rt reinstall`.
+- If you need cluster-specific storage, ingress, or TLS behavior, those are configuration changes on top of the default single-node setup, not built-in assumptions.

--- a/source/introduction/overview.md
+++ b/source/introduction/overview.md
@@ -1,68 +1,90 @@
 # Overview
 
-AUP Learning Cloud is a tailored JupyterHub deployment designed to provide an intuitive and hands-on AI learning experience. It features a comprehensive suite of AI toolkits running on AMD hardware acceleration, enabling users to learn and experiment with ease.
+AUP Learning Cloud is a JupyterHub-based learning platform for curated course environments, custom repositories, and shared GPU-enabled workspaces on Kubernetes.
 
 ```{image} ../_static/images/software-stack.png
 :alt: Software Architecture
 :align: center
 ```
 
-## What is AUP Learning Cloud?
+## What It Provides
 
-AUP Learning Cloud provides a multi-user Jupyter notebook environment optimized for AI and machine learning education on AMD hardware platforms.
+### Resource Selection At Spawn Time
 
-## Key Features
+Users do not launch into a single fixed notebook image. The platform presents a resource picker that can expose:
 
-### Hardware Acceleration
+- course environments such as CV, DL, LLM, and PhySim
+- generic CPU or GPU environments
+- accelerator-specific options defined by the deployment
+- optional Git repository cloning on startup
 
-- **AMD GPU**: Leverage ROCm on AMD Ryzen™ AI iGPUs (Strix Halo, Strix) and AMD Radeon™ RDNA 4 discrete GPUs (RX 9070 XT, AI Pro R9700) for high-performance deep learning and AI workloads
-- **AMD CPU**: Support for general-purpose CPU-based computations
+What each user can see is controlled by JupyterHub group membership and `custom.teams.mapping`.
 
-### Flexible Deployment
+### Multiple Authentication Modes
 
-Kubernetes provides a robust infrastructure for deploying and managing JupyterHub. We support both single-node and multi-node K3s cluster deployments, and produce offline install bundles for air-gapped environments.
+The Hub currently supports four authentication modes:
 
-### Custom URL Launcher
+- `auto-login`
+- `dummy`
+- `github`
+- `multi`
 
-We provide a basic **ROCm + PyTorch** environment; you can clone your own Git repository into this environment at server start (via URL and branch or by selecting a repo from your GitHub account). Private repositories are supported via a GitHub App or a pre-configured default access token. Your code is then available in the workspace so you can run it immediately.
+`multi` combines GitHub OAuth and native local accounts on one login page. In GitHub-backed deployments, GitHub team membership can be synchronized into JupyterHub groups and used for resource access control.
 
-### Authentication
+### Admin Console
 
-Seamless integration with GitHub Single Sign-On (SSO) and Native Authenticator for secure and efficient user authentication:
+The built-in admin console at `/hub/admin` includes:
 
-- **Auto-admin on install**: Initial admin created automatically with random password
-- **Dual login**: GitHub OAuth + Native accounts on single login page
-- **GitHub Teams → Groups sync**: GitHub team membership is mapped to JupyterHub groups for resource access control
-- **Batch user management**: CSV/Excel-based bulk operations via scripts
+- a **Users** view for creating users, resetting passwords, managing quotas, and starting or stopping servers
+- a **Groups** view for reviewing group membership and group-to-resource mappings
+- a **Dashboard** view for usage analytics, active sessions, pending spawns, and resource distribution
 
-### Admin Dashboard
+### Quota And Usage Tracking
 
-A dedicated React-based admin dashboard (under `/hub/admin/`) provides user/group management and a live usage view — daily active users, active sessions (via Server-Sent Events), pending spawns, idle-session warnings, and course/accelerator usage breakdowns. Quotas can be applied and reset in batch.
+When quota is enabled, the platform tracks usage sessions, enforces minimum balance before spawn, supports unlimited users, and can apply scheduled refresh rules with Kubernetes CronJobs.
 
-### Observability
+### Monitoring And Metrics
 
-Optional Prometheus + Grafana integration exposes Hub and single-user metrics. Two preset Grafana dashboards ship with the chart (`grafana-dashboard-aup-hub-ops.json`, `grafana-dashboard-aup-hub-resources.json`).
+The chart can expose Hub metrics to Prometheus and optionally install ServiceMonitor, PrometheusRule, and Grafana dashboard resources.
 
-### Storage Management and Security
+## Deployment Modes
 
-Dynamic NFS provisioning ensures scalable and persistent storage for user data, while Traefik ingress with automated TLS certificate management guarantees secure and reliable communication.
+### Single-Node
+
+The primary workstation/developer flow uses `./auplc-installer` to install K3s, prepare runtime values, and deploy the Hub.
+
+The checked-in default values in this repository currently describe a local deployment with:
+
+- NodePort access on `30890`
+- `local-path` storage
+- ingress disabled
+- prePuller disabled
+
+### Multi-Node
+
+Cluster deployments use the Ansible playbooks in `deploy/ansible/` plus Helm deployment with `runtime/values-multi-nodes.yaml.example` as the starting point.
+
+NFS storage, ingress, TLS, and other production-oriented components are deployment choices, not mandatory defaults.
 
 ## Learning Solutions
 
-AUP Learning Cloud offers the following Learning Toolkits:
+AUP Learning Cloud currently ships the following learning toolkits:
 
-- **Computer Vision** - 10 hands-on labs covering common computer vision concepts and techniques
-- **Deep Learning** - 12 hands-on labs covering common deep learning concepts and techniques
-- **Large Language Model from Scratch** - 9 hands-on labs designed to teach LLM development from scratch
-- **Physics Simulation** - Hands-on labs for physics simulation with GPU acceleration
+- **Computer Vision**
+- **Deep Learning**
+- **Large Language Models**
+- **Physics Simulation**
 
-## Available Notebook Environments
+## Acknowledgment
 
-| Environment | Image | Hardware |
-|------------|-------|----------|
-| Base CPU | `ghcr.io/amdresearch/auplc-default` | CPU |
-| GPU Base | `ghcr.io/amdresearch/auplc-base` | GPU |
-| CV Course | `ghcr.io/amdresearch/auplc-cv` | GPU |
-| DL Course | `ghcr.io/amdresearch/auplc-dl` | GPU |
-| LLM Course | `ghcr.io/amdresearch/auplc-llm` | GPU |
-| PhySim Course | `ghcr.io/amdresearch/auplc-physim` | GPU |
+AUP would like to thank the following universities and professors. This learning solution was made possible through the joint efforts of these partners.
+
+| University | Professors and Labs | Toolkits |
+|---|---|---|
+| National Taiwan University | [Prof. Chun-Yi Lee](https://www.csie.ntu.edu.tw/en/member/Faculty/Chun-Yi-Lee-67240464), [ELSA Lab](https://elsalab.ai/) | DL, CV |
+| Nanjing University | [Prof. Jingwei Xu](https://njudeepengine.github.io/jingweixu/), [NJUDeepEngine](https://github.com/NJUDeepEngine) | LLM |
+
+The following repositories and icons are used in AUP Learning Cloud, either in close to original form or as an inspiration:
+
+- [Genesis](https://github.com/Genesis-Embodied-AI/Genesis)
+- [Flaticon](https://www.flaticon.com): deployment (Prashanth Rapolu 15, Freepik), team and user (Freepik), machine learning (Becris)

--- a/source/jupyterhub/README.md
+++ b/source/jupyterhub/README.md
@@ -2,187 +2,112 @@
 
 ## Documentation
 
-- [Authentication Guide](./authentication-guide.md) - Setup GitHub OAuth and native authentication
-- [User Management Guide](./user-management.md) - Batch user operations with scripts
-- [User Quota System](./quota-system.md) - Resource usage tracking and quota management
-- [GitHub App Setup](./github-oauth-setup.md) - Step-by-step GitHub App configuration
-- [Configuration Reference](./configuration-reference.md) - Complete `runtime/values.yaml` reference
+- [Authentication Guide](./authentication-guide.md) - Authentication modes, GitHub org sync, native accounts, and admin bootstrap
+- [User Management Guide](./user-management.md) - Admin console and CLI-based user operations
+- [User Quota System](./quota-system.md) - Quota balances, rates, refresh rules, and admin actions
+- [GitHub App Setup](./github-oauth-setup.md) - Optional GitHub App integration for private repository access
+- [Configuration Reference](./configuration-reference.md) - Detailed `runtime/values.yaml` and chart configuration
 
 ---
 
 ## Configuration Files Overview
 
-The Helm chart uses a layered configuration approach:
+The Hub runtime is configured through layered Helm values.
 
 | File | Purpose |
 |------|---------|
-| `runtime/chart/values.yaml` | Chart defaults (accelerators, resources, teams, quota settings) |
-| `runtime/values.yaml` | Deployment overrides (environment-specific settings) |
-| `runtime/values.local.yaml` | Local development overrides (gitignored) |
+| `runtime/chart/values.yaml` | Chart defaults and full schema |
+| `runtime/values.yaml` | Current single-node oriented deployment defaults in this repository |
+| `runtime/values.local.yaml` | Optional local overrides (typically gitignored) |
+| `runtime/values-multi-nodes.yaml.example` | Standalone multi-node example values file |
 
 ### Helm Merge Behavior
 
-- **Maps/Objects**: Deep merge (new keys added, same keys override)
-- **Arrays/Lists**: Complete replacement
+- **Maps / objects** are merged.
+- **Arrays / lists** are replaced.
 
-Deploy with:
-```bash
-# Production
-helm upgrade jupyterhub ./chart -n jupyterhub -f values.yaml
-
-# Local development
-helm upgrade jupyterhub ./chart -n jupyterhub -f values.yaml -f values.local.yaml
-```
+That means overriding `custom.teams.mapping.gpu` replaces the whole list, not just one item.
 
 ---
 
-## Custom Configuration
+## Current Platform Surfaces
 
-All custom settings are under the `custom` section. Chart defaults are in `runtime/chart/values.yaml`.
+### Authentication
 
-### Authentication Mode
+The current Hub supports four auth modes via `custom.authMode`:
 
-```yaml
-custom:
-  authMode: "auto-login"  # auto-login | dummy | github | multi
-```
+- `auto-login` - Automatically logs everyone in as a shared user for simple installs
+- `dummy` - Accepts any username/password for testing only
+- `github` - GitHub OAuth only
+- `multi` - GitHub OAuth plus native local accounts on a single login page
 
-| Mode | Description |
-|------|-------------|
-| `auto-login` | No credentials, auto-login as 'student' (single-node dev) |
-| `dummy` | Accept any username/password (testing) |
-| `github` | GitHub OAuth only |
-| `multi` | GitHub OAuth + Local accounts |
+In GitHub-backed modes, the Hub can also sync GitHub team membership into JupyterHub groups and use those groups for resource visibility.
 
-### Admin User Auto-Creation
+### Spawn Experience
 
-```yaml
-custom:
-  adminUser:
-    enabled: true  # Generate admin credentials on install
-```
+The spawn page is no longer just an image chooser. It can present:
 
-When enabled, credentials are stored in a Kubernetes secret:
-```bash
-# Get admin password
-kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
-  -o jsonpath='{.data.admin-password}' | base64 -d
+- grouped resources from `custom.resources.metadata`
+- accelerator-specific options from `custom.accelerators`
+- team-filtered resource visibility from `custom.teams.mapping`
+- quota-aware runtime limits
+- optional Git URL validation and clone-at-start behavior
+- GitHub App repo picker support when `custom.gitClone.githubAppName` is configured
 
-# Get API token
-kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
-  -o jsonpath='{.data.api-token}' | base64 -d
-```
+### Admin Console
 
-### Accelerators (GPU/NPU)
+The React admin console under `/hub/admin` has three main areas:
 
-Define available hardware accelerators:
+- **Users** - Create users, reset passwords, edit quota, start/stop servers, inspect usage
+- **Groups** - Manage manually controlled groups, inspect GitHub-synced groups, review resource mappings
+- **Dashboard** - View summary cards, resource usage, top users, active sessions, and pending spawns
 
-```yaml
-custom:
-  accelerators:
-    phx:
-      displayName: "AMD Radeon 780M (Phoenix Point iGPU)"
-      description: "RDNA 3.0 (gfx1103) | Compute Units 12 | 4GB LPDDR5X"
-      nodeSelector:
-        node-type: phx
-      env:
-        HSA_OVERRIDE_GFX_VERSION: "11.0.0"
-      quotaRate: 2
-    my-custom-gpu:
-      displayName: "My Custom GPU"
-      nodeSelector:
-        node-type: my-gpu
-      quotaRate: 3
-```
+### Announcements and Onboarding
 
-### Resources (Images & Requirements)
+Announcements can be injected through `hub.extraFiles.announcement.txt`. The home page also includes a dismissible onboarding flow backed by Hub APIs.
 
-Define container images and resource requirements:
+### Monitoring
 
-```yaml
-custom:
-  resources:
-    images:
-      cpu: "ghcr.io/amdresearch/auplc-default:latest"
-      Course-CV: "ghcr.io/amdresearch/auplc-cv:latest"
-      my-course: "my-registry/my-image:latest"
-
-    requirements:
-      cpu:
-        cpu: "2"
-        memory: "4Gi"
-        memory_limit: "6Gi"
-      Course-CV:
-        cpu: "4"
-        memory: "16Gi"
-        memory_limit: "24Gi"
-        amd.com/gpu: "1"
-      my-course:
-        cpu: "4"
-        memory: "8Gi"
-```
-
-### Teams Mapping
-
-Map teams to allowed resources:
-
-```yaml
-custom:
-  teams:
-    mapping:
-      cpu:
-        - cpu
-      gpu:
-        - Course-CV
-        - Course-DL
-      native-users:
-        - cpu
-        - Course-CV
-```
-
-:::{note}
-Arrays are completely replaced when overriding. If you override `teams.mapping.gpu`, the entire list is replaced, not merged.
-:::
-
-### Quota System
-
-```yaml
-custom:
-  quota:
-    enabled: null        # null = auto-detect based on authMode
-    cpuRate: 1           # Quota rate for CPU-only containers
-    minimumToStart: 10   # Minimum quota to start a container
-    defaultQuota: 0      # Default quota for new users
-
-    refreshRules:
-      daily-topup:
-        enabled: true
-        schedule: "0 0 * * *"
-        action: add
-        amount: 100
-        maxBalance: 500
-        targets:
-          includeUnlimited: false
-          balanceBelow: 400
-```
-
-See [quota-system.md](./quota-system.md) for detailed documentation.
+The chart supports Prometheus metrics, ServiceMonitor, PrometheusRule, and Grafana dashboard installation through the `monitoring.*` values.
 
 ---
 
-## Hub Configuration
+## Current Deployment Defaults In This Repository
 
-### Hub Image
+The checked-in `runtime/values.yaml` currently describes a simple local deployment:
 
-```yaml
-hub:
-  image:
-    name: ghcr.io/amdresearch/auplc-hub
-    tag: latest
-    pullPolicy: IfNotPresent
+- `proxy.service.type: NodePort`
+- `proxy.service.nodePorts.http: 30890`
+- `ingress.enabled: false`
+- `hub.db.pvc.storageClassName: local-path`
+- `singleuser.storage.dynamic.storageClass: local-path`
+- `prePuller.hook.enabled: false`
+- `prePuller.continuous.enabled: false`
+
+So the default local workflow in this repository is HTTP + NodePort + local-path storage, not ingress + TLS + NFS.
+
+---
+
+## Common Workflows
+
+### Apply Configuration Changes
+
+**Single-node:**
+
+```bash
+sudo ./auplc-installer rt upgrade
 ```
 
-### Login Page Announcement
+**Multi-node / manual Helm:**
+
+```bash
+cd runtime
+helm upgrade --install jupyterhub ./chart \
+  -n jupyterhub --create-namespace \
+  -f values-multi-nodes.yaml
+```
+
+### Edit Login / Home Announcement
 
 ```yaml
 hub:
@@ -190,176 +115,31 @@ hub:
     announcement.txt:
       mountPath: /usr/local/share/jupyterhub/static/announcement.txt
       stringData: |
-        <div class="announcement-box" style="padding: 1em; border: 1px solid #ccc;">
-          <h3>Welcome!</h3>
+        <div class="announcement-box">
+          <h3>Welcome</h3>
           <p>Your announcement here.</p>
         </div>
 ```
 
-### GitHub Authentication
-
-GitHub authentication uses a [GitHub App](https://docs.github.com/en/apps) for login and optional private repository access.
+### Enable Git Clone With GitHub App Support
 
 ```yaml
 custom:
   gitClone:
-    githubAppName: "your-app-slug"  # Enables private repo access & repo picker
-
-hub:
-  config:
-    GitHubOAuthenticator:
-      oauth_callback_url: "https://<Your.domain>/hub/github/oauth_callback"
-      client_id: "<GitHub App Client ID>"
-      client_secret: "<GitHub App Client Secret>"
-      allowed_organizations:
-        - YOUR-ORG-NAME
-      scope: []  # GitHub App uses App-level permissions, not OAuth scopes
-```
-
-See [GitHub App Setup](./github-oauth-setup.md) for setup instructions.
-
-### Git Repository Cloning
-
-Resources with `allowGitClone: true` show a Git URL input on the spawn page. Users can clone a repository at container startup.
-
-```yaml
-custom:
-  gitClone:
+    githubAppName: "your-app-slug"
     allowedProviders:
       - github.com
       - gitlab.com
-    maxCloneTimeout: 300
+      - bitbucket.org
 ```
 
-#### Private Repository Access
-
-Two independent mechanisms (can be used together):
-
-**1. GitHub App** -- for GitHub OAuth users
-
-Set `githubAppName` (see above). Users authorize per-repo read-only access via the GitHub App UI. A repo picker appears on the spawn page showing authorized repositories.
-
-**2. Default Access Token** -- for all users including auto-login
-
-```yaml
-custom:
-  gitClone:
-    defaultAccessToken: "ghp_xxxx"  # Bot/service account PAT
-```
-
-Admin-configured PAT applied transparently to all users. Helm auto-creates a K8s Secret. Useful for classroom / single-node setups where everyone needs access to the same private repos without GitHub login.
-
-Token priority: OAuth token (GitHub App) > defaultAccessToken > none (public only)
+For GitHub App setup details, see [GitHub App Setup](./github-oauth-setup.md).
 
 ---
 
-## Network Settings
+## Recommended Reading Order
 
-### NodePort Access
-
-```yaml
-proxy:
-  service:
-    type: NodePort
-    nodePorts:
-      http: 30890
-
-ingress:
-  enabled: false
-```
-
-Access via `http://<node-ip>:30890`
-
-### Domain Access with Ingress
-
-```yaml
-proxy:
-  service:
-    type: ClusterIP
-
-ingress:
-  enabled: true
-  ingressClassName: traefik
-  hosts:
-    - your.domain.com
-  tls:
-    - hosts:
-        - your.domain.com
-      secretName: jupyter-tls-cert
-```
-
----
-
-## Storage Settings
-
-### NFS Storage (Production)
-
-```yaml
-hub:
-  db:
-    pvc:
-      storageClassName: nfs-client
-
-singleuser:
-  storage:
-    dynamic:
-      storageClass: nfs-client
-```
-
-### Local Storage (Development)
-
-```yaml
-hub:
-  db:
-    pvc:
-      storageClassName: hostpath
-
-singleuser:
-  storage:
-    dynamic:
-      storageClass: hostpath
-```
-
----
-
-## PrePuller Settings
-
-Pre-download images to all nodes for faster container startup:
-
-```yaml
-prePuller:
-  hook:
-    enabled: true
-  continuous:
-    enabled: true
-  extraImages:
-    aup-cpu-notebook:
-      name: ghcr.io/amdresearch/auplc-default
-      tag: latest
-```
-
-For faster deployment (images pulled on-demand):
-
-```yaml
-prePuller:
-  hook:
-    enabled: false
-  continuous:
-    enabled: false
-```
-
----
-
-## Applying Changes
-
-After modifying configuration:
-
-```bash
-helm upgrade jupyterhub ./chart -n jupyterhub -f values.yaml
-```
-
-Or use the installer:
-
-```bash
-sudo ./auplc-installer rt upgrade
-```
+1. Start with [Configuration Reference](./configuration-reference.md)
+2. Then read [Authentication Guide](./authentication-guide.md)
+3. For operational tasks, use [User Management Guide](./user-management.md)
+4. For quota-enabled deployments, read [User Quota System](./quota-system.md)

--- a/source/jupyterhub/authentication-guide.md
+++ b/source/jupyterhub/authentication-guide.md
@@ -1,445 +1,158 @@
 # Authentication Guide
 
-This guide covers the dual authentication system and user management for AUP Learning Cloud.
-
-## Table of Contents
-
-- Overview
-- Authentication Methods
-- Configuration
-- Admin Management
-- User Management
-- Deployment
-- Troubleshooting
+This guide describes the current authentication behavior of AUP Learning Cloud, including auth modes, GitHub team sync, native accounts, and admin bootstrap.
 
 ## Overview
 
-AUP Learning Cloud supports **dual authentication** to accommodate different user types:
+Authentication is controlled by `custom.authMode`.
 
-1. **GitHub OAuth**: For technical teams and organization members
-2. **Native Authenticator**: For students and external users (admin-managed accounts)
+Supported modes:
 
-### Key Features
+| Mode | Meaning |
+|------|---------|
+| `auto-login` | Shared local mode with no credentials |
+| `dummy` | Testing mode that accepts any username/password |
+| `github` | GitHub OAuth only |
+| `multi` | GitHub OAuth plus native local accounts |
 
-- **Auto-admin on install**: Initial admin created automatically with random password
-- **No self-registration**: Only admins can create native accounts
-- **Individual passwords**: Each user has their own password (can be changed)
-- **Unified admin panel**: All users managed in `/hub/admin`
-- **Batch operations**: CSV/Excel-based bulk user management
-- **Script-based admin management**: Use `set-admin` command
+The current checked-in single-node defaults use `auto-login`.
 
-## Authentication Methods
+## Admin Bootstrap
 
-### Comparison
-
-| Feature | GitHub OAuth | Native Authenticator |
-|---------|--------------|---------------------|
-| **User Type** | Technical teams, org members | Students, external users |
-| **Account Creation** | GitHub organization invite | Admin creates manually |
-| **Password** | Managed by GitHub | User-defined (changeable) |
-| **Access Control** | Based on GitHub teams | Based on username patterns or groups |
-| **Best For** | Staff, developers, researchers | Course students, temporary users |
-
-### Login Flow
-
-Users see a combined login page with GitHub OAuth button and native login form:
-
-```
-+-------------------------------+
-|  JupyterHub Login              |
-+-------------------------------+
-|  [ Sign in with GitHub ]       | <-- GitHub OAuth
-|                                |
-|  --- Or use local account ---  |
-|                                |
-|  Username: [____________]      |
-|  Password: [____________]      | <-- Native Auth
-|  [ Sign In ]                   |
-+-------------------------------+
-```
-
-## Configuration
-
-### Enable Auto-Admin (Recommended)
-
-In `runtime/values.yaml` or `runtime/values-local.yaml`:
-
-```yaml
-custom:
-  adminUser:
-    enabled: true    # Auto-create admin on helm install
-```
-
-This automatically:
-1. Generates random API token and admin password
-2. Creates `jupyterhub-admin-credentials` secret
-3. Configures `admin` user with admin privileges on hub startup
-
-The API token is associated with the `admin` user for script operations.
-
-### Get Credentials After Install
-
-```bash
-# Get admin password
-kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
-  -o go-template='{{index .data "admin-password" | base64decode}}'
-
-# Get API token for scripts
-export JUPYTERHUB_TOKEN=$(kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
-  -o go-template='{{index .data "api-token" | base64decode}}')
-```
-
-### Resource Access Mapping
-
-Configure which resources different user groups can access in `values.yaml`:
-
-```yaml
-custom:
-  teams:
-    mapping:
-      cpu:
-        - cpu
-      gpu:
-        - Course-CV
-        - Course-DL
-        - Course-LLM
-      official:
-        - cpu
-        - Course-CV
-        - Course-DL
-        - Course-LLM
-      native-users:
-        - Course-CV
-        - Course-DL
-        - Course-LLM
-```
-
-### Native Authenticator Settings
-
-The `CustomFirstUseAuthenticator` class settings:
-
-```python
-class CustomFirstUseAuthenticator(FirstUseAuthenticator):
-    service_name = "Native"
-    create_users = False  # Only admin-created users can login
-```
-
-**Important**: `create_users = False` prevents users from creating accounts themselves. Users must be created by an admin first.
-
-## Admin Management
-
-### Initial Admin
-
-Created automatically on `helm install` when `custom.adminUser.enabled: true`.
-
-### Adding More Admins
-
-Use the `set-admin` command (NOT config files):
-
-```bash
-# Grant admin to users
-python scripts/manage_users.py set-admin teacher01 teacher02
-
-# Grant admin from file
-python scripts/manage_users.py set-admin -f new_admins.csv
-
-# Revoke admin
-python scripts/manage_users.py set-admin --revoke student01
-```
-
-Or via Admin Panel (`/hub/admin`):
-1. Click username
-2. Check "Admin" checkbox
-3. Save
-
-### Admin Users Summary
-
-| Method | When to Use |
-|--------|-------------|
-| `custom.adminUser.enabled: true` | Initial admin on install |
-| `manage_users.py set-admin` | Add/remove admins later |
-| Admin Panel `/hub/admin` | Quick single-user changes |
-
-## User Management
-
-### Prerequisites
-
-Install required dependencies:
-
-```bash
-pip install pandas openpyxl requests
-```
-
-Set environment variables:
-
-```bash
-export JUPYTERHUB_URL="http://localhost:30890"  # Or your hub URL
-export JUPYTERHUB_TOKEN=$(kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
-  -o go-template='{{index .data "api-token" | base64decode}}')
-```
-
-### Batch User Operations
-
-For detailed batch user management, see [User Management Guide](user-management.md).
-
-**Quick Reference**:
-
-```bash
-# Generate user template
-python scripts/generate_users_template.py --prefix student --count 50 --output users.csv
-
-# Create users from file
-python scripts/manage_users.py create users.csv
-
-# List all users
-python scripts/manage_users.py list
-
-# Grant admin privileges
-python scripts/manage_users.py set-admin teacher01 teacher02
-
-# Revoke admin privileges
-python scripts/manage_users.py set-admin --revoke student01
-
-# Export/backup users
-python scripts/manage_users.py export backup.xlsx
-
-# Delete users
-python scripts/manage_users.py delete remove_list.csv
-```
-
-### Manual User Management
-
-Via JupyterHub Admin Panel (`/hub/admin`):
-
-1. **Add single user**: Click "Add Users" button
-2. **Delete user**: Click username -> "Delete User"
-3. **Make admin**: Click username -> Check "Admin" -> "Save"
-4. **Stop user server**: Click "Stop Server" button
-
-## Deployment
-
-### 1. Update Hub Image
-
-The Hub Docker image must include the `jupyterhub-nativeauthenticator` dependency.
-
-**File**: `dockerfiles/Hub/Dockerfile`
-
-```dockerfile
-RUN pip install jupyterhub-multiauthenticator jupyterhub-firstuseauthenticator
-```
-
-### 2. Rebuild Hub Image
-
-```bash
-cd dockerfiles/Hub
-./build.sh
-
-# Or manually:
-docker build -t ghcr.io/amdresearch/auplc-hub:latest .
-docker push ghcr.io/amdresearch/auplc-hub:latest
-```
-
-### 3. Update Helm Values
-
-**File**: `runtime/values.yaml`
+Admin bootstrap is optional.
 
 ```yaml
 custom:
   adminUser:
     enabled: true
-
-hub:
-  image:
-    name: ghcr.io/amdresearch/auplc-hub
-    tag: latest
 ```
 
-### 4. Deploy or Upgrade
+When enabled, the Hub creates the `jupyterhub-admin-credentials` secret and bootstraps the `admin` user.
+
+Retrieve credentials with:
 
 ```bash
-cd runtime
-helm upgrade jupyterhub ./chart -n jupyterhub -f values.yaml
-```
-
-Or using the installer:
-
-```bash
-sudo ./auplc-installer rt upgrade
-```
-
-### 5. Verify Deployment
-
-```bash
-# Check hub pod is running
-kubectl --namespace=jupyterhub get pods
-
-# Check hub logs for admin setup
-kubectl --namespace=jupyterhub logs deployment/hub | grep -i admin
-
-# Get admin password
 kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
   -o jsonpath='{.data.admin-password}' | base64 -d && echo
+
+kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
+  -o jsonpath='{.data.api-token}' | base64 -d && echo
 ```
 
-## Troubleshooting
+## GitHub OAuth
 
-### Issue: "Module 'nativeauthenticator' not found"
+GitHub OAuth configuration lives under `hub.config.GitHubOAuthenticator`.
 
-**Cause**: Hub image doesn't have `jupyterhub-nativeauthenticator` installed.
+```yaml
+custom:
+  githubOrgName: "your-github-org"
 
-**Solution**:
-```bash
-# Rebuild Hub image with updated Dockerfile
-cd dockerfiles/Hub
-./build.sh
+hub:
+  config:
+    GitHubOAuthenticator:
+      oauth_callback_url: "https://your.domain.com/hub/github/oauth_callback"
+      client_id: "TODO"
+      client_secret: "TODO"
+      allowed_organizations:
+        - your-github-org
+      scope:
+        - read:user
+        - read:org
 ```
 
-### Issue: Users can self-register
+### GitHub Team Sync
 
-**Cause**: `create_users` is not set to `False`.
+In GitHub-backed deployments, the Hub can:
 
-**Solution**: Verify in `jupyterhub_config.py`:
-```python
-class CustomFirstUseAuthenticator(FirstUseAuthenticator):
-    create_users = False
+- fetch the user's team memberships during login
+- refresh team memberships again at spawn time
+- map those teams into JupyterHub groups
+- use group membership to control visible resources
+
+The org name used for synchronization comes from `custom.githubOrgName`.
+
+## GitHub App Integration For Repositories
+
+GitHub App integration is optional and is related to private repository cloning, not to basic OAuth login itself.
+
+```yaml
+custom:
+  gitClone:
+    githubAppName: "your-app-slug"
 ```
 
-### Issue: API token authentication fails
+When configured, GitHub-authenticated users can install or authorize the app and use repo-picker flows on the spawn page.
 
-**Symptoms**:
-```
-Connection failed with status 403
-```
+For setup instructions, see [GitHub App Setup](github-oauth-setup.md).
 
-**Solutions**:
+## Native Accounts
 
-1. **Verify secret exists**:
-   ```bash
-   kubectl -n jupyterhub get secret jupyterhub-admin-credentials
-   ```
+Native accounts are used in `multi` mode.
 
-2. **Check token is loaded**:
-   ```bash
-   kubectl -n jupyterhub logs deployment/hub | grep "API token"
-   ```
+Important behavior:
 
-3. **Regenerate credentials**:
-   ```bash
-   kubectl -n jupyterhub delete secret jupyterhub-admin-credentials
-   helm upgrade jupyterhub ./chart -n jupyterhub -f values.yaml
-   ```
+- users cannot self-register arbitrarily
+- admins can create users from the web admin console or CLI scripts
+- native passwords can be reset by admins
+- users can be forced to change password on next login
 
-### Issue: Admin not created on install
+## Group-Based Resource Access
 
-**Symptoms**: No admin user after helm install.
-
-**Solutions**:
-
-1. **Verify config**:
-   ```yaml
-   custom:
-     adminUser:
-       enabled: true  # Must be true
-   ```
-
-2. **Check hub logs**:
-   ```bash
-   kubectl -n jupyterhub logs deployment/hub | grep -i "admin"
-   ```
-
-3. **Restart hub**:
-   ```bash
-   kubectl -n jupyterhub rollout restart deployment/hub
-   ```
-
-### Issue: Wrong resource permissions
-
-**Symptoms**: User sees courses they shouldn't access, or missing expected courses.
-
-**Solution**: Check resource mapping in `values.yaml`:
+Resource visibility is controlled by `custom.teams.mapping`.
 
 ```yaml
 custom:
   teams:
     mapping:
-      gpu:
+      github-users:
+        - cpu
+        - gpu
+      native-users:
+        - cpu
         - Course-CV
-        - Course-DL
-        - Course-LLM
-      # Verify user's team membership in GitHub org
 ```
 
-### Issue: Users created but can't login
+GitHub-synced groups and system-managed groups have protection rules in the admin surface.
 
-**Cause**: Native users must set password on first login.
+## Recommended Operational Flow
 
-**Solution**:
+### Single-Node
 
-1. User should go to login page
-2. Enter username created by admin
-3. Enter desired password
-4. Password is saved for future logins
+After editing auth-related values, redeploy with:
 
-**Alternative**: Set passwords via script:
 ```bash
-python scripts/manage_users.py set-passwords users.csv --generate
+sudo ./auplc-installer rt upgrade
 ```
 
-### Issue: Batch script fails to connect
+### Manual / Multi-Node Helm
 
-**Symptoms**:
+```bash
+cd runtime
+helm upgrade --install jupyterhub ./chart \
+  -n jupyterhub --create-namespace \
+  -f values-multi-nodes.yaml
 ```
-Connection error: Connection refused
-```
 
-**Solutions**:
+## Troubleshooting
 
-1. **Verify JupyterHub URL**:
-   ```bash
-   # For local dev
-   export JUPYTERHUB_URL="http://localhost:30890"
+### GitHub Users Do Not See Expected Resources
 
-   # For production
-   export JUPYTERHUB_URL="https://your-domain.com"
-   ```
+Check:
 
-2. **Check if hub is accessible**:
-   ```bash
-   curl $JUPYTERHUB_URL/hub/api/
-   ```
+- `custom.githubOrgName`
+- `hub.config.GitHubOAuthenticator.allowed_organizations`
+- `custom.teams.mapping`
 
-3. **Verify namespace and port forwarding** (if using kubectl):
-   ```bash
-   kubectl --namespace=jupyterhub port-forward service/hub 8081:8081
-   export JUPYTERHUB_URL="http://localhost:8081"
-   ```
+### No Admin User Was Created
 
-## Security Best Practices
+Confirm that `custom.adminUser.enabled: true` is set, then restart or upgrade the runtime.
 
-1. **Protect API tokens**:
-   - Tokens are stored in Kubernetes secrets
-   - Never commit tokens to git
-   - Rotate tokens by deleting and recreating the secret
+### Native Users Cannot Log In
 
-2. **User password policy**:
-   - Encourage strong passwords
-   - Consider adding password complexity requirements
+Confirm the deployment is using `multi` mode and that the user was created by an administrator.
 
-3. **Admin accounts**:
-   - Limit number of admin users
-   - Use `set-admin` command to manage (auditable)
-   - Review admin list regularly
+## Related Documentation
 
-4. **GitHub App**:
-   - Create the App under the organization, not a personal account
-   - Keep GitHub organization membership updated
-   - Review team permissions regularly
-   - Set `scope: []` -- permissions are configured in the App settings
-
-## Additional Resources
-
-- [User Management Guide](user-management.md) - Batch user operations and scripts
-- [JupyterHub Documentation](https://jupyterhub.readthedocs.io/)
-- [NativeAuthenticator Documentation](https://native-authenticator.readthedocs.io/)
-- [JupyterHub REST API](https://jupyterhub.readthedocs.io/en/stable/reference/rest-api.html)
-- [OAuthenticator Documentation](https://oauthenticator.readthedocs.io/)
+- [GitHub App Setup](github-oauth-setup.md)
+- [User Management Guide](user-management.md)
+- [Configuration Reference](configuration-reference.md)

--- a/source/jupyterhub/configuration-reference.md
+++ b/source/jupyterhub/configuration-reference.md
@@ -1,74 +1,74 @@
-# Configuration Reference: runtime/values.yaml
+# Configuration Reference: `runtime/values.yaml`
 
-This page describes how to configure the main deployment file **`runtime/values.yaml`**. This file is the environment-specific override used when deploying with Helm; all available options and defaults are defined in **`runtime/chart/values.yaml`**.
+This page describes the main configuration surfaces used by AUP Learning Cloud.
 
-:::{important}
-**File location**: The primary configuration file is **`runtime/values.yaml`** (in the repo under the `runtime/` directory; there is no `runtime/core/values.yml` path — the "core" config is this file). The Helm chart defaults live in **`runtime/chart/values.yaml`**. When you run `helm install` or `helm upgrade`, you pass `-f values.yaml` from the `runtime/` directory.
-:::
+The most important distinction is:
 
-## Quick reference
+- `runtime/chart/values.yaml` defines chart defaults and the full supported schema
+- `runtime/values.yaml` provides the repository's current deployment defaults
+- `runtime/values-multi-nodes.yaml.example` is a standalone starting point for multi-node installs
+
+## Quick Reference
+
+### Single-Node Runtime Update
 
 ```bash
-# Deploy from repository root (develop branch)
-cd runtime
-helm install jupyterhub ./chart -n jupyterhub --create-namespace -f values.yaml
+sudo ./auplc-installer rt upgrade
+```
 
-# Upgrade after editing values
-helm upgrade jupyterhub ./chart -n jupyterhub -f values.yaml
+### Direct Helm Upgrade
+
+```bash
+cd runtime
+helm upgrade --install jupyterhub ./chart \
+  -n jupyterhub --create-namespace \
+  -f values.yaml
 ```
 
 ---
 
-## 1. `custom` — AUP-specific configuration
-
-All AUP Learning Cloud–specific behavior is under **`custom`**. These values are passed to the hub pod and used by the custom JupyterHub image.
-
-### 1.1 `custom.authMode`
-
-Authentication mode for the hub.
-
-| Value | Description |
-|-------|-------------|
-| `auto-login` | No credentials; everyone is logged in as a single user (e.g. `student`). Best for single-node dev/demo. |
-| `dummy` | Accept any username/password. For testing only. |
-| `github` | GitHub OAuth only. |
-| `multi` | GitHub OAuth + local (native) accounts on one login page. |
-
-**Example:**
+## 1. `custom.authMode`
 
 ```yaml
 custom:
-  authMode: "auto-login"   # or "github", "multi", "dummy"
+  authMode: "auto-login"
 ```
 
-### 1.2 `custom.adminUser`
+Supported values:
 
-Optionally create an admin user and credentials on first install.
+| Value | Meaning |
+|------|---------|
+| `auto-login` | Shared no-credential local mode |
+| `dummy` | Testing-only any-user mode |
+| `github` | GitHub OAuth only |
+| `multi` | GitHub OAuth plus native accounts |
+
+## 2. `custom.adminUser`
 
 ```yaml
 custom:
   adminUser:
-    enabled: false   # Set true to auto-create admin + jupyterhub-admin-credentials secret
+    enabled: false
 ```
 
-When `enabled: true`, a random admin password and API token are stored in the `jupyterhub-admin-credentials` secret. See [Authentication Guide](authentication-guide.md).
+If enabled, the chart creates the `jupyterhub-admin-credentials` secret and bootstraps the `admin` user. This is optional and currently disabled in the checked-in defaults.
 
-### 1.3 `custom.gitClone` — Git repository cloning
+## 3. `custom.githubOrgName`
 
-Controls optional Git URL on the spawn form; the repo is cloned into the user's home at container start via an init container.
+```yaml
+custom:
+  githubOrgName: "your-github-org"
+```
 
-**Private repo access (two options, can be combined):**
+Used by the Hub's GitHub team synchronization logic. This is especially relevant in `github` and `multi` auth modes.
 
-- **GitHub App** (`githubAppName`): For GitHub OAuth users; token comes from OAuth. Requires migrating from OAuth App to GitHub App (see comments in `runtime/values.yaml`).
-- **Default access token** (`defaultAccessToken`): A single PAT used for all users (including auto-login). Good for classroom/single-node when everyone needs the same private repos.
-
-**Token priority:** OAuth token (GitHub App) &gt; `defaultAccessToken` &gt; none (public only).
+## 4. `custom.gitClone`
 
 ```yaml
 custom:
   gitClone:
-    githubAppName: ""           # e.g. "aup-learning-cloud" — GitHub App slug
-    defaultAccessToken: ""      # Bot PAT for all users (K8s Secret created by Helm)
+    githubAppName: ""
+    defaultAccessToken: ""
     allowedProviders:
       - github.com
       - gitlab.com
@@ -77,193 +77,172 @@ custom:
     initContainerImage: "alpine/git:2.47.2"
 ```
 
-### 1.4 `custom.accelerators` — GPU/NPU node types
+Key behavior:
 
-Defines accelerator types shown in the spawn UI and used for scheduling and quota.
+- `githubAppName` enables GitHub App install / repo picker flows for GitHub-authenticated users
+- `defaultAccessToken` provides a fallback private-repo token for all users
+- token priority is GitHub OAuth token first, then `defaultAccessToken`
+- a resource must also opt in with `metadata.allowGitClone: true`
 
-Each key (e.g. `strix-halo`, `dgpu`) is an accelerator **key**. Each entry can set:
-
-- **displayName**, **description**: Shown in the UI.
-- **nodeSelector**: Must match node labels so user pods land on the right hardware.
-- **env**: Environment variables for the user container (e.g. `HSA_OVERRIDE_GFX_VERSION`).
-- **quotaRate**: Quota consumed per minute when using this accelerator.
-
-**Example:**
+## 5. `custom.accelerators`
 
 ```yaml
 custom:
   accelerators:
-    strix-halo:
-      displayName: "AMD Radeon™ 8060S (Strix Halo iGPU)"
-      description: "RDNA 3.5 (gfx1151) | Compute Units 40 | 64GB LPDDR5X"
+    r9700:
+      displayName: "AMD Radeon™ AI Pro R9700 (Workstation GPU)"
+      description: "RDNA 4.0 (gfx1201) | Compute Units 64 | 32GB GDDR6"
       nodeSelector:
-        node-type: strix-halo
-      env: {}
-      quotaRate: 3
-    dgpu:
-      displayName: "AMD Radeon™ 9070XT (Desktop GPU)"
-      description: "RDNA 4.0 (gfx1201) | ..."
-      nodeSelector:
-        node-type: dgpu
+        amd.com/gpu.product-name: "AMD_Radeon_AI_PRO_R9700"
       env: {}
       quotaRate: 4
 ```
 
-Ensure your nodes are labeled (e.g. `kubectl label nodes <name> node-type=strix-halo`).
+Supported fields:
 
-### 1.5 `custom.resources` — Course images and options
+- `displayName`
+- `description`
+- `nodeSelector`
+- `env`
+- `quotaRate`
 
-Three sub-sections: **images**, **requirements**, **metadata**.
+For current single-node installs, selectors are typically derived from ROCm labeller keys such as `amd.com/gpu.product-name`, not legacy `node-type` labels.
 
-**`custom.resources.images`**  
-Maps logical names (e.g. `cpu`, `Course-CV`) to container images.
+## 6. `custom.resources`
+
+### Images
 
 ```yaml
 custom:
   resources:
     images:
       cpu: "ghcr.io/amdresearch/auplc-default:latest"
-      gpu: "ghcr.io/amdresearch/base-gfx1151:v0.1-full"
+      gpu: "ghcr.io/amdresearch/auplc-base:latest"
       Course-CV: "ghcr.io/amdresearch/auplc-cv:latest"
-      Course-DL: "ghcr.io/amdresearch/auplc-dl:latest"
-      Course-LLM: "ghcr.io/amdresearch/auplc-llm:latest"
-      Course-PhySim: "ghcr.io/amdresearch/auplc-physim:latest"
 ```
 
-**`custom.resources.requirements`**  
-Kubernetes resource requests/limits per profile (same keys as `images`).
+### Requirements
 
 ```yaml
 custom:
   resources:
     requirements:
-      cpu:
-        cpu: "2"
-        memory: "4Gi"
-        memory_limit: "6Gi"
       gpu:
-        cpu: "4"
-        memory: "16Gi"
-        memory_limit: "24Gi"
+        cpu: "0"
+        memory: "0Gi"
         amd.com/gpu: "1"
-      Course-CV:
-        cpu: "4"
-        memory: "16Gi"
-        memory_limit: "24Gi"
-        amd.com/gpu: "1"
-      # ... same pattern for other courses
-      none:
-        cpu: "2"
-        memory: "4Gi"
-        memory_limit: "6Gi"
 ```
 
-**`custom.resources.metadata`**  
-UI text and behavior for each profile (group, description, which accelerators, allow Git clone).
+Recognized fields include:
+
+- `cpu`
+- `memory`
+- `memory_limit`
+- `amd.com/gpu`
+- `amd.com/npu`
+
+### Metadata
 
 ```yaml
 custom:
   resources:
     metadata:
-      cpu:
+      gpu:
         group: "CUSTOM REPO"
-        description: "Basic Python Environment"
-        subDescription: "CPU Only Environment"
-        accelerator: ""
-        acceleratorKeys: []
-        allowGitClone: true
-      Course-CV:
-        group: "COURSE"
-        description: "Computer Vision Course"
-        subDescription: "Suitable for CV experiments with GPU"
+        description: "Basic GPU Environment"
+        subDescription: "GPU Accelerated Environment"
         accelerator: "GPU"
         acceleratorKeys:
           - strix-halo
-        allowGitClone: true   # if applicable
+        allowGitClone: true
+        env: {}
 ```
 
-### 1.6 `custom.teams.mapping` — Team → course access
+Supported metadata fields:
 
-Maps **team names** (from auth, e.g. GitHub teams or native groups) to a list of **resource keys** (from `custom.resources.images` / `metadata`).
+- `group`
+- `description`
+- `subDescription`
+- `accelerator`
+- `acceleratorKeys`
+- `allowGitClone`
+- `env`
+- `acceleratorOverrides`
+
+`acceleratorOverrides` can override image and env per accelerator key:
+
+```yaml
+custom:
+  resources:
+    metadata:
+      Course-CV:
+        acceleratorOverrides:
+          r9700:
+            image: "ghcr.io/example/auplc-cv:latest-gfx120x"
+            env:
+              HSA_OVERRIDE_GFX_VERSION: ""
+```
+
+## 7. `custom.teams.mapping`
 
 ```yaml
 custom:
   teams:
     mapping:
-      cpu:
-        - cpu
-      gpu:
-        - Course-CV
-        - Course-DL
-        - Course-LLM
-        - Course-PhySim
-      official:
+      github-users:
         - cpu
         - gpu
-        - Course-CV
-        - Course-DL
-        - Course-LLM
-        - Course-PhySim
-      AUP:
-        - Course-CV
-        - Course-DL
-        - Course-LLM
-        - Course-PhySim
       native-users:
+        - cpu
         - Course-CV
-        - Course-DL
-        - Course-LLM
 ```
 
-Users in a team only see and can spawn the listed profiles.
+This mapping controls which resources a user can see, based on JupyterHub group membership.
 
-### 1.7 `custom.quota` — Quota system
-
-See [User Quota System](quota-system.md) for full detail. Summary:
+## 8. `custom.quota`
 
 ```yaml
 custom:
   quota:
-    enabled: null        # null = auto (on for github/multi, off for auto-login/dummy)
-    cpuRate: 1           # Quota per minute for CPU-only
-    minimumToStart: 10   # Minimum balance to start any container
-    defaultQuota: 0      # Initial quota for new users (0 = none)
-    refreshRules: {}     # CronJobs for periodic top-up/reset (see quota-system.md)
+    enabled: null
+    cpuRate: 1
+    minimumToStart: 10
+    defaultQuota: 0
+    refreshRules: {}
 ```
 
----
+Important behavior:
 
-## 2. `hub` — JupyterHub pod
+- when `enabled` is `null`, quota auto-disables for `auto-login` and `dummy`
+- accelerator-specific `quotaRate` values come from `custom.accelerators.*`
+- `refreshRules` create CronJob-based balance refresh behavior
 
-### 2.1 Database and image
+## 9. `custom.hub.allowedOrigins` and `custom.notebook.allowedOrigins`
 
 ```yaml
-hub:
-  db:
-    pvc:
-      storageClassName: local-path   # Use K3s local-path (single-node) or your StorageClass
-  image:
-    name: ghcr.io/amdresearch/auplc-hub
-    tag: latest
-    pullPolicy: IfNotPresent
+custom:
+  hub:
+    allowedOrigins: []
+  notebook:
+    allowedOrigins: []
 ```
 
-### 2.2 `hub.extraConfig`
+- `custom.hub.allowedOrigins` adds Hub CORS headers
+- `custom.notebook.allowedOrigins` is applied to notebook server startup arguments
 
-Additional Python config (snippets) executed after the core setup. Use for one-off JupyterHub/traitlets settings.
+## 10. `custom.security.publicScheme`
+
+When TLS is terminated outside the chart, you can tell the Hub to treat the public origin as HTTPS:
 
 ```yaml
-hub:
-  extraConfig: {}
-  # Example:
-  # extraConfig:
-  #   myconfig: |
-  #     c.JupyterHub.some_setting = "value"
+custom:
+  security:
+    publicScheme: "https"
 ```
 
-### 2.3 `hub.extraFiles`
+This affects secure handling of `_xsrf` cookies.
 
-Inject files into the hub container (e.g. announcement HTML, custom templates).
+## 11. `hub.extraFiles`
 
 ```yaml
 hub:
@@ -271,88 +250,54 @@ hub:
     announcement.txt:
       mountPath: /usr/local/share/jupyterhub/static/announcement.txt
       stringData: |
-        <div class="announcement-box">...</div>
+        <div class="announcement-box">Notice</div>
 ```
 
-### 2.4 `hub.config` — JupyterHub and authenticator config
+Used for login / home announcements and other injected files.
 
-This is the main place for **JupyterHub**, **Authenticator**, **KubeSpawner**, and **GitHub OAuth** settings. Keys are class names; values are traitlets.
+## 12. `monitoring`
 
-**Typical sections:**
+```yaml
+monitoring:
+  enabled: false
+  hubMetrics:
+    enabled: false
+    allowUnauthenticatedScrape: false
+  serviceMonitor:
+    enabled: false
+  grafana:
+    dashboard:
+      enabled: false
+  prometheusRule:
+    enabled: false
+```
+
+This controls Prometheus scraping and optional Grafana / alerting resources.
+
+## 13. Local Deployment Defaults In `runtime/values.yaml`
+
+The repository's current local defaults are:
 
 ```yaml
 hub:
-  config:
-    Authenticator:
-      allow_all: true   # For dummy/auto-login
-    GitHubOAuthenticator:
-      oauth_callback_url: "https://<Your.domain>/hub/github/oauth_callback"
-      client_id: "TODO"
-      client_secret: "TODO"
-      allowed_organizations:
-        - <YOUR-ORG-NAME>
-      scope: []  # GitHub App uses App-level permissions, not OAuth scopes
-    KubeSpawner:
-      image_pull_policy: IfNotPresent
-```
+  db:
+    pvc:
+      storageClassName: local-path
 
-See [GitHub OAuth Setup](github-oauth-setup.md) and [Authentication Guide](authentication-guide.md).
-
----
-
-## 3. `singleuser` — User notebook pods
-
-### 3.1 Storage
-
-User home directory persistence. For single-node K3s, `local-path` is typical.
-
-```yaml
 singleuser:
   storage:
     dynamic:
       storageClass: local-path
-```
 
-For multi-node or NFS, set `storageClass` to your provisioner (e.g. `nfs-client`).
-
----
-
-## 4. `proxy` — Access (NodePort or LoadBalancer)
-
-**NodePort (single-node / dev):**
-
-```yaml
 proxy:
   service:
     type: NodePort
     nodePorts:
       http: 30890
-```
 
-Access at `http://<node-ip>:30890`.
-
-**LoadBalancer / Ingress:** Use `type: LoadBalancer` or leave default and use `ingress` below.
-
----
-
-## 5. `ingress`
-
-For NodePort-only access, disable ingress:
-
-```yaml
 ingress:
   enabled: false
-```
 
-For domain-based access, enable and set hosts/TLS; see [README](README.md) network examples.
-
----
-
-## 6. `prePuller` — Image pre-pulling
-
-Pre-pulling can speed up first spawn; for dev it’s often disabled to speed up deploy.
-
-```yaml
 prePuller:
   hook:
     enabled: false
@@ -360,36 +305,4 @@ prePuller:
     enabled: false
 ```
 
-To pre-pull images, set `hook.enabled` and/or `continuous.enabled` to `true` and (if needed) add `prePuller.extraImages` with the same image list you use in `custom.resources.images`.
-
----
-
-## 7. Suggested workflow for editing `runtime/values.yaml`
-
-1. **Auth**: Set `custom.authMode` and, for GitHub, `hub.config.GitHubOAuthenticator` (and optionally `custom.gitClone.githubAppName`).
-2. **Admin**: Set `custom.adminUser.enabled` if you want auto-created admin credentials.
-3. **Courses**: Add or change entries in `custom.resources.images`, `requirements`, and `metadata`, and ensure `custom.teams.mapping` grants the right teams access.
-4. **Accelerators**: Match `custom.accelerators` to your node labels and quota; set `quotaRate` per accelerator.
-5. **Quota**: Tune `custom.quota` and, if needed, `refreshRules` (see [quota-system](quota-system.md)).
-6. **Storage**: Set `hub.db.pvc.storageClassName` and `singleuser.storage.dynamic.storageClass` (e.g. `local-path` for K3s).
-7. **Access**: Choose NodePort (`proxy.service.type: NodePort`, `ingress.enabled: false`) or domain + ingress.
-8. **Announcement / branding**: Edit `hub.extraFiles.announcement.txt` (or add more `extraFiles`).
-
-After any change, run from `runtime/`:
-
-```bash
-helm upgrade jupyterhub ./chart -n jupyterhub -f values.yaml
-```
-
----
-
-## 8. Recommendations and best practices
-
-- **Version images explicitly**: Prefer tags like `v1.0` over `latest` in `custom.resources.images` and `hub.image.tag` for reproducible deployments.
-- **Secrets**: Do not commit real `client_secret`, `defaultAccessToken`, or passwords. Use a separate `values-local.yaml` or `--set` / sealed secrets / external secrets.
-- **Quota**: For production with real users, enable quota (`custom.quota.enabled: true` if not using auto-login/dummy) and set `defaultQuota` or use `refreshRules` so users receive allocations.
-- **Node labels**: Ensure every GPU/NPU node has the labels referenced in `custom.accelerators.*.nodeSelector` so scheduling works.
-- **Teams**: Keep `custom.teams.mapping` in sync with your GitHub org/teams or native group naming so users see the correct course list.
-- **Backup**: Back up the hub DB PVC (and any NFS storage) before major upgrades or config changes.
-
-For more detail on auth, quotas, and OAuth, see the other guides in this section.
+Treat NFS, ingress, TLS, and pre-pulling as opt-in deployment features unless you explicitly configure them.

--- a/source/jupyterhub/configuration-reference.md
+++ b/source/jupyterhub/configuration-reference.md
@@ -106,7 +106,7 @@ Supported fields:
 - `env`
 - `quotaRate`
 
-For current single-node installs, selectors are typically derived from ROCm labeller keys such as `amd.com/gpu.product-name`, not legacy `node-type` labels.
+Current checked-in values use ROCm labeller keys such as `amd.com/gpu.product-name` rather than a separate legacy `node-type` label model.
 
 ## 6. `custom.resources`
 
@@ -169,18 +169,16 @@ Supported metadata fields:
 - `env`
 - `acceleratorOverrides`
 
-`acceleratorOverrides` can override image and env per accelerator key:
+`acceleratorOverrides` can override images per accelerator key, and may also override env when a deployment needs that level of control:
 
 ```yaml
 custom:
   resources:
-    metadata:
-      Course-CV:
-        acceleratorOverrides:
-          r9700:
-            image: "ghcr.io/example/auplc-cv:latest-gfx120x"
-            env:
-              HSA_OVERRIDE_GFX_VERSION: ""
+      metadata:
+        Course-CV:
+          acceleratorOverrides:
+            r9700:
+              image: "ghcr.io/your-org/auplc-cv:<tag-for-r9700>"
 ```
 
 ## 7. `custom.teams.mapping`

--- a/source/jupyterhub/quota-system.md
+++ b/source/jupyterhub/quota-system.md
@@ -1,145 +1,100 @@
 # User Quota System
 
-The quota system manages and tracks resource usage for JupyterHub users. It enables administrators to allocate, monitor, and control how much compute time users can consume.
+The quota system tracks usage sessions and can block new spawns when a user lacks enough balance.
 
-## Overview
+## What Quota Controls
 
-### Key Concepts
+When quota is enabled, the current flow is:
 
-- **Balance**: The amount of quota credits a user has available
-- **Rate**: The cost per minute for different resource types (CPU, GPU, NPU)
-- **Session**: A tracked period of container usage that consumes quota
-- **Unlimited Quota**: Special status exempting users from quota deductions
-
-### How It Works
-
-1. User requests to start a container
-2. System checks if user has sufficient quota for the estimated runtime
-3. If sufficient, a usage session begins tracking time
-4. When container stops, actual usage is calculated and quota is deducted
-5. Formula: `quota_consumed = rate × duration_minutes`
+1. a user chooses a resource and runtime on the spawn page
+2. the Hub computes the estimated cost from the selected accelerator rate and runtime
+3. the Hub blocks the spawn if the user cannot afford it
+4. a usage session is recorded while the server runs
+5. quota is deducted when the session ends
 
 ## Configuration
 
-Configure the quota system in your Helm values.yaml under `custom.quota`:
+Quota is configured under `custom.quota`.
 
 ```yaml
 custom:
   quota:
-    enabled: null              # Enable/disable quota system (null = auto-detect based on authMode)
-    cpuRate: 1                 # Cost per minute for CPU-only containers
-    minimumToStart: 10         # Minimum quota required to start any container
-    defaultQuota: 0            # Default quota granted to new users (0 = no initial allocation)
+    enabled: null
+    cpuRate: 1
+    minimumToStart: 10
+    defaultQuota: 0
+    refreshRules: {}
 ```
 
-### New User Default Quota
+### Field Meanings
 
-The `defaultQuota` setting controls how much quota new users receive automatically:
+| Field | Meaning |
+|------|---------|
+| `enabled` | Explicit on/off. When `null`, quota auto-disables for `auto-login` and `dummy` |
+| `cpuRate` | Per-minute cost for CPU-only sessions |
+| `minimumToStart` | Minimum balance required before any spawn can start |
+| `defaultQuota` | Initial balance granted to new users when their quota record is created |
+| `refreshRules` | Scheduled balance refresh rules implemented as CronJobs |
 
-- **Value `0` (default)**: New users start with zero quota and must be manually granted quota by an administrator
-- **Value `> 0`**: New users are automatically granted this amount when they first attempt to use the system
+## Accelerator Rates
 
-**Example configuration:**
-```yaml
-custom:
-  quota:
-    defaultQuota: 100  # Automatically grant 100 quota units to new users
-```
-
-#### How It Works
-
-This automatic allocation happens when a new user first tries to start a container. The system will:
-1. Check if the user has a quota record in the database
-2. If not found and `defaultQuota > 0`, create a record with the default amount
-3. Record this as an "initial_grant" transaction in the audit log
-
-### Unlimited Quota
-
-Unlimited quota status is managed via the Admin UI. To grant unlimited quota to a user:
-1. Go to the Admin Panel (`/hub/admin/users`)
-2. Click on the user's quota value
-3. Enter `-1`, `∞`, or `unlimited` in the input field
-4. Click Save
-
-### Quota Rates by Resource Type
-
-Each accelerator type can have a different quota rate defined in `custom.accelerators`:
+Accelerator-specific rates come from `custom.accelerators.*.quotaRate`.
 
 ```yaml
 custom:
   accelerators:
-    phx:
-      quotaRate: 2          # Phoenix iGPU: 2 quota/minute
-    strix:
-      quotaRate: 2          # Strix iGPU: 2 quota/minute
     strix-halo:
-      quotaRate: 3          # Strix Halo iGPU: 3 quota/minute
-    dgpu:
-      quotaRate: 4          # Discrete GPU: 4 quota/minute
-    strix-npu:
-      quotaRate: 1          # NPU: 1 quota/minute
+      quotaRate: 3
+    r9700:
+      quotaRate: 4
 ```
 
-### Auto-Enable Behavior
+The effective estimated cost is:
 
-The quota system is automatically enabled/disabled based on authentication mode:
-- **Enabled**: `github`, `multi` authentication modes
-- **Disabled**: `auto-login`, `dummy` modes (typically for development)
+```text
+quota cost = runtime_minutes × selected accelerator rate
+```
 
-### Scheduled Quota Refresh (CronJob)
+If no accelerator is selected, the CPU rate is used.
 
-You can configure automatic quota refresh rules that run on a schedule. Each rule creates a Kubernetes CronJob.
+## Auto-Enable Behavior
 
-#### Basic Setup
+When `custom.quota.enabled` is left as `null`:
 
-Add refresh rules to your `values.yaml`:
+- `auto-login` and `dummy` default to quota disabled
+- `github` and `multi` default to quota enabled
+
+## Unlimited Quota
+
+The platform supports unlimited users.
+
+In the current admin UI, unlimited quota can be set by entering:
+
+- `-1`
+- `∞`
+- `unlimited`
+
+## Web Admin Operations
+
+The current `/hub/admin/users` page supports:
+
+- inline per-user quota editing
+- batch quota updates for selected users
+- toggling unlimited quota
+- viewing current balances alongside server status
+
+The admin UI also includes a **Refresh Quota** action that can apply a global add-or-set operation to all users.
+
+## Scheduled Quota Refresh Rules
+
+`refreshRules` allow periodic top-ups or resets.
+
+Example:
 
 ```yaml
 custom:
   quota:
     refreshRules:
-      daily-topup:
-        enabled: true
-        schedule: "0 0 * * *"       # Every day at midnight
-        action: add                  # add or set
-        amount: 100                  # Add 100 quota daily
-        maxBalance: 500              # Cap balance at 500
-        targets:
-          includeUnlimited: false    # Skip unlimited users
-```
-
-#### Configuration Options
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `enabled` | bool | Enable/disable this rule |
-| `schedule` | string | Cron expression (e.g., `"0 0 * * *"` = daily at midnight) |
-| `action` | string | `add` (default) or `set` |
-| `amount` | int | Quota amount (positive to add, negative to deduct) |
-| `maxBalance` | int | Maximum balance cap (for `add` action) |
-| `minBalance` | int | Minimum balance floor (prevents going negative) |
-| `targets` | object | Targeting rules (see below) |
-
-#### Targeting Options
-
-Filter which users are affected:
-
-| Target | Type | Description |
-|--------|------|-------------|
-| `includeUnlimited` | bool | Include users with unlimited quota |
-| `balanceBelow` | int | Only users with balance below this value |
-| `balanceAbove` | int | Only users with balance above this value |
-| `includeUsers` | list | Only these specific usernames |
-| `excludeUsers` | list | Exclude these usernames |
-| `usernamePattern` | string | Regex pattern (e.g., `"^student_.*"`) |
-
-#### Example Rules
-
-```yaml
-custom:
-  quota:
-    refreshRules:
-      # Daily top-up: Add 100 to users below 400
       daily-topup:
         enabled: true
         schedule: "0 0 * * *"
@@ -149,478 +104,48 @@ custom:
         targets:
           includeUnlimited: false
           balanceBelow: 400
-
-      # Monthly reset: Set everyone to 500
-      monthly-reset:
-        enabled: true
-        schedule: "0 0 1 * *"        # 1st of each month
-        action: set
-        amount: 500
-        targets:
-          includeUnlimited: false
-
-      # Weekly decay: Deduct 50 from users above 100
-      weekly-decay:
-        enabled: false
-        schedule: "0 0 * * 0"        # Every Sunday
-        amount: -50
-        minBalance: 0
-        targets:
-          balanceAbove: 100
 ```
 
-#### Cron Schedule Syntax
+These rules create Kubernetes CronJobs during deployment.
 
-```
-┌───────────── minute (0-59)
-│ ┌───────────── hour (0-23)
-│ │ ┌───────────── day of month (1-31)
-│ │ │ ┌───────────── month (1-12)
-│ │ │ │ ┌───────────── day of week (0-6, Sun=0)
-│ │ │ │ │
-* * * * *
-```
-
-Common examples:
-- `"0 0 * * *"` - Daily at midnight
-- `"0 8 * * 1-5"` - Weekdays at 8:00 AM
-- `"0 0 1 * *"` - 1st of each month at midnight
-- `"0 0 * * 0"` - Every Sunday at midnight
-- `"*/30 * * * *"` - Every 30 minutes
-
-#### Verify CronJobs
-
-After `helm upgrade`, check if CronJobs are created:
+Useful verification commands:
 
 ```bash
-# List quota refresh CronJobs
 kubectl -n jupyterhub get cronjobs -l app.kubernetes.io/component=quota-refresh
-
-# Check recent job runs
 kubectl -n jupyterhub get jobs -l app.kubernetes.io/component=quota-refresh
-
-# View logs from last run
 kubectl -n jupyterhub logs -l app.kubernetes.io/component=quota-refresh --tail=50
 ```
 
-## Admin Operations
+## Runtime Behavior Details
 
-### Web Interface (Admin Panel)
+Current implementation details worth knowing:
 
-The Admin Panel provides a graphical interface for quota management. Access it at `/hub/admin/users`.
+- new users get a quota record on first use
+- `defaultQuota` is applied at record creation time
+- usage sessions are tracked even when quota deduction is disabled
+- unlimited users skip balance deduction
+- insufficient balance blocks spawn before the server starts
 
-![Users Page with Quota](../_static/images/jupyterhub/quota-1-users-page.png)
+## Recommended Deployment Flow
 
-#### Quota Column
+After changing quota configuration:
 
-When the quota system is enabled, the Users page displays a **Quota** column showing each user's balance.
-
-#### Inline Editing
-
-Click directly on a user's quota value to edit:
-- Enter a new number and press **Enter** to save
-- Press **Escape** to cancel
-- Enter `-1`, `∞`, or `unlimited` to grant unlimited status
-
-![Inline Quota Editing](../_static/images/jupyterhub/quota-2-inline-edit.png)
-
-#### Batch Operations
-
-1. Select multiple users using checkboxes
-2. Click "Set Quota" button (appears when users are selected)
-
-![Batch Select Users](../_static/images/jupyterhub/quota-3-batch-select.png)
-
-3. Enter the quota value:
-   - A number (e.g., `500`) to set exact balance
-   - `-1`, `∞`, or `unlimited` to grant unlimited status
-4. Click "Apply" to update all selected users
-
-![Batch Quota Modal](../_static/images/jupyterhub/quota-4-batch-modal.png)
-
-### REST API Endpoints
-
-All admin endpoints require authentication. Admin-specific operations require admin privileges.
-
-#### List All User Quotas
-
-```
-GET /admin/api/quota/
-```
-
-**Response:**
-```json
-{
-  "users": [
-    {"username": "user1", "balance": 500, "unlimited": false, "updated_at": "2026-01-15T10:00:00"},
-    {"username": "user2", "balance": 1000, "unlimited": true, "updated_at": "2026-01-15T09:30:00"}
-  ]
-}
-```
-
-#### Get Single User Quota
-
-```
-GET /admin/api/quota/<username>
-```
-
-**Response:**
-```json
-{
-  "username": "user1",
-  "balance": 500,
-  "unlimited": false,
-  "recent_transactions": [
-    {
-      "id": 123,
-      "username": "user1",
-      "amount": -10,
-      "transaction_type": "usage",
-      "resource_type": "cpu",
-      "description": "Session 456: 10 minutes",
-      "balance_before": 510,
-      "balance_after": 500,
-      "created_at": "2026-01-15T10:00:00",
-      "created_by": null
-    }
-  ]
-}
-```
-
-#### Modify User Quota
-
-```
-POST /admin/api/quota/<username>
-Content-Type: application/json
-```
-
-```json
-{
-  "action": "set",
-  "amount": 100,
-  "unlimited": true,
-  "description": "Monthly allocation"
-}
-```
-
-- `action`: `"set"`, `"add"`, `"deduct"`, or `"set_unlimited"`
-- `amount`: Required for set/add/deduct
-- `unlimited`: Required for set_unlimited
-
-**Actions:**
-- `set`: Set balance to exact amount
-- `add`: Add amount to current balance
-- `deduct`: Subtract amount from balance
-- `set_unlimited`: Mark/unmark user as having unlimited quota
-
-**Response:**
-```json
-{
-  "username": "user1",
-  "balance": 100,
-  "action": "set",
-  "amount": 100
-}
-```
-
-#### Batch Set Quota
-
-```
-POST /admin/api/quota/batch
-Content-Type: application/json
-```
-
-```json
-{
-  "users": [
-    {"username": "user1", "amount": 100},
-    {"username": "user2", "amount": 200}
-  ]
-}
-```
-
-**Response:**
-```json
-{
-  "success": 2,
-  "failed": 0,
-  "details": [
-    {"username": "user1", "status": "success", "balance": 100},
-    {"username": "user2", "status": "success", "balance": 200}
-  ]
-}
-```
-
-#### Batch Refresh Quota
-
-Flexible batch operation with targeting rules:
-
-```
-POST /admin/api/quota/refresh
-Content-Type: application/json
-```
-
-```json
-{
-  "rule_name": "weekly_reset",
-  "action": "add",
-  "amount": 100,
-  "max_balance": 1000,
-  "min_balance": 0,
-  "targets": {
-    "includeUnlimited": false,
-    "balanceBelow": 500,
-    "balanceAbove": 0,
-    "includeUsers": ["user1"],
-    "excludeUsers": ["admin"],
-    "usernamePattern": "^student_.*"
-  }
-}
-```
-
-Request fields:
-- `action`: `"add"` or `"set"`
-- `max_balance`: Optional cap for balance
-- `min_balance`: Optional floor for balance
-
-**Targeting Rules (AND logic):**
-- `includeUnlimited`: Whether to include users marked as unlimited
-- `balanceBelow`: Only affect users with balance below this value
-- `balanceAbove`: Only affect users with balance above this value
-- `includeUsers`: Whitelist of specific usernames
-- `excludeUsers`: Blacklist of usernames to skip
-- `usernamePattern`: Regex pattern to match usernames
-
-**Response:**
-```json
-{
-  "users_updated": 25,
-  "total_change": 2500,
-  "skipped": 5,
-  "action": "add",
-  "rule_name": "weekly_reset"
-}
-```
-
-### CLI Commands (manage_users.py)
-
-The `manage_users.py` script provides command-line quota management via kubectl.
-
-#### Set Quota
-
-Set quota to a specific amount:
+**Single-node:**
 
 ```bash
-# Set quota for specific users
-python scripts/manage_users.py set-quota user1 user2 --amount 1000
-
-# Set quota from file (requires username column, optional quota column)
-python scripts/manage_users.py set-quota -f users.csv --amount 500
-
-# File with per-user amounts
-python scripts/manage_users.py set-quota -f users_with_quota.csv
+sudo ./auplc-installer rt upgrade
 ```
 
-**File format (users_with_quota.csv):**
-```text
-username,quota
-student01,500
-student02,1000
-teacher01,2000
-```
-
-#### Add Quota
-
-Add quota to existing balance:
+**Manual / multi-node Helm:**
 
 ```bash
-# Add to specific users
-python scripts/manage_users.py add-quota user1 user2 --amount 100
-
-# Add to users from file
-python scripts/manage_users.py add-quota -f users.csv --amount 50
+cd runtime
+helm upgrade --install jupyterhub ./chart \
+  -n jupyterhub --create-namespace \
+  -f values-multi-nodes.yaml
 ```
 
-#### List Quota Balances
+## Related Pages
 
-Display all user quota balances:
-
-```bash
-python scripts/manage_users.py list-quota
-```
-
-**Output:**
-```
-📋 Quota Balances (25 users):
-
-Username                  Balance         Last Updated
------------------------------------------------------------------
-student01                 450             2026-01-15 10:30:00
-student02                 800             2026-01-15 09:15:00
-teacher01                 1500            2026-01-14 16:45:00
-```
-
-## User Experience
-
-### Viewing Personal Quota
-
-Users can check their quota via the API:
-
-```
-GET /api/quota/me
-```
-
-**Response:**
-```json
-{
-  "username": "student01",
-  "balance": 450,
-  "unlimited": false,
-  "rates": {"cpu": 1, "phx": 2, "strix": 2},
-  "enabled": true
-}
-```
-
-To get accelerator options, use the separate `/api/accelerators` endpoint.
-
-### Quota Rates API
-
-Get quota rates and configuration (available to all authenticated users):
-
-```
-GET /api/quota/rates
-```
-
-**Response:**
-```json
-{
-  "enabled": true,
-  "rates": {"cpu": 1, "phx": 2, "strix": 2},
-  "minimum_to_start": 10
-}
-```
-
-- `enabled`: Whether the quota system is active
-- `rates`: Quota consumption rate per minute for each resource type
-- `minimum_to_start`: Minimum quota required to start any container
-
-### Accelerators API
-
-Get available accelerator options (always available, independent of quota system):
-
-```
-GET /api/accelerators
-```
-
-**Response:**
-```json
-{
-  "accelerators": {
-    "phx": {
-      "displayName": "AMD Radeon™ 780M (Phoenix Point iGPU)",
-      "description": "RDNA 3.0 (gfx1103) | Compute Units 12 | 4GB LPDDR5X",
-      "nodeSelector": {"accelerator": "phx"},
-      "quotaRate": 2
-    }
-  }
-}
-```
-
-- `accelerators`: Available accelerator options with display name, description, node selector, and quota rate
-
-### Insufficient Quota
-
-When a user attempts to start a container without sufficient quota:
-
-1. System calculates estimated cost: `rate × requested_runtime`
-2. Compares with current balance and minimum requirement
-3. If insufficient, returns HTTP 403 error with message:
-
-```
-Cannot start container: Insufficient quota. Current balance: 5,
-estimated cost: 120 (2 quota/min × 60 min).
-Please contact administrator to add quota.
-```
-
-### Quota Deduction
-
-Quota is deducted when a container stops:
-
-1. System records actual duration (minimum 1 minute)
-2. Calculates actual cost: `rate × actual_duration_minutes`
-3. Deducts from user balance
-4. Records transaction in audit log
-
-## Technical Details
-
-### Stale Session Cleanup
-
-Sessions stuck for more than 8 hours are automatically cleaned up on hub startup:
-
-- Marks session as `cleaned_up`
-- Records duration but does NOT deduct quota (avoids charging for crashed sessions)
-- Logs cleanup for auditing
-
-### Unlimited Quota Logic
-
-A user has unlimited quota if marked `unlimited: true` in the database.
-
-## Troubleshooting
-
-### User Cannot Start Container
-
-**Symptom:** "Insufficient quota" error
-
-**Solutions:**
-1. Check user's current balance:
-   ```bash
-   python scripts/manage_users.py list-quota | grep username
-   ```
-
-2. Add quota to user:
-   ```bash
-   python scripts/manage_users.py add-quota username --amount 500
-   ```
-
-3. Or grant unlimited quota via Admin UI (click quota value and enter `∞`)
-
-### Quota Not Being Deducted
-
-**Symptom:** User's balance doesn't decrease after container use
-
-**Possible causes:**
-1. User has unlimited quota (set via Admin UI)
-2. Quota system is disabled (`custom.quota.enabled: false`)
-3. Session ended abnormally (cleaned up as stale)
-
-**Check:**
-```bash
-# View user's transaction history
-curl "$JUPYTERHUB_URL/admin/api/quota/username" \
-  -H "Authorization: token $JUPYTERHUB_TOKEN"
-```
-
-### Session Stuck as Active
-
-**Symptom:** Old sessions show as active even though containers stopped
-
-**Solution:** Sessions are automatically cleaned on hub restart, or manually:
-```bash
-# Restart hub to trigger cleanup
-kubectl -n jupyterhub rollout restart deployment/hub
-```
-
-### Database Issues
-
-**Location:** `/srv/jupyterhub/quota.sqlite` (inside hub pod)
-
-**Access for debugging:**
-```bash
-kubectl -n jupyterhub exec deployment/hub -- sqlite3 /srv/jupyterhub/quota.sqlite \
-  "SELECT * FROM user_quota LIMIT 10;"
-```
-
-## See Also
-
-- [User Management Guide](./user-management.md) - Batch user operations
-- [Authentication Guide](./authentication-guide.md) - User authentication setup
+- [User Management Guide](user-management.md)
+- [Configuration Reference](configuration-reference.md)

--- a/source/jupyterhub/user-management.md
+++ b/source/jupyterhub/user-management.md
@@ -1,387 +1,153 @@
 # User Management Guide
 
-This guide covers user management via the Admin Panel (web interface) and CLI scripts.
+This guide covers the current user-management surfaces in AUP Learning Cloud.
 
-## Prerequisites
+There are now two real workflows:
 
-```bash
-# Install dependencies
-pip install pandas openpyxl requests
+- **Web admin console** at `/hub/admin`
+- **CLI scripts** for spreadsheet-driven bulk operations
+
+The web console is now the primary day-to-day interface.
+
+## Admin Bootstrap
+
+If you want the chart to create the initial admin credentials automatically:
+
+```yaml
+custom:
+  adminUser:
+    enabled: true
 ```
 
-## Initial Setup
-
-### Auto-Admin on Helm Install
-
-When `custom.adminUser.enabled: true` is set in values.yaml, helm install automatically:
-
-1. Generates random API token and admin password
-2. Creates `jupyterhub-admin-credentials` secret
-3. Configures `admin` user with admin privileges on hub startup
-
-The API token is associated with the `admin` user for script operations.
-
-**Get credentials after install:**
+Then retrieve the credentials with:
 
 ```bash
-# Get admin password
 kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
-  -o go-template='{{index .data "admin-password" | base64decode}}'
+  -o jsonpath='{.data.admin-password}' | base64 -d && echo
 
-# Get API token
-export JUPYTERHUB_TOKEN=$(kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
-  -o go-template='{{index .data "api-token" | base64decode}}')
+kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
+  -o jsonpath='{.data.api-token}' | base64 -d && echo
 ```
 
-### Manual Setup (if auto-admin disabled)
+## Web Admin Console
 
-If `custom.adminUser.enabled: false`, create credentials manually:
+Open `/hub/admin` after logging in as an admin user.
 
-```bash
-# Create secret with random token and password
-kubectl -n jupyterhub create secret generic jupyterhub-admin-credentials \
-  --from-literal=api-token=$(openssl rand -hex 32) \
-  --from-literal=admin-password=$(openssl rand -base64 12)
+### Users View
 
-# Restart hub to apply
-kubectl -n jupyterhub rollout restart deployment/hub
-```
+The **Users** page supports:
 
-## Daily Usage
+- searching and paging users
+- filtering to users with active servers
+- inline quota editing when quota is enabled
+- starting and stopping user servers
+- creating native users
+- editing user details
+- resetting passwords for native users
+- batch password reset for selected native users
+- batch quota update for selected users
+- batch delete for deletable users
+- opening a per-user usage detail view
 
-### Set Environment Variables
+Important behavior from the current implementation:
 
-```bash
-# Get token from Kubernetes secret
-export JUPYTERHUB_TOKEN=$(kubectl -n jupyterhub get secret jupyterhub-admin-credentials \
-  -o go-template='{{index .data "api-token" | base64decode}}')
-export JUPYTERHUB_URL="http://localhost:30890"  # Or your hub URL
-```
+- admin users and the currently logged-in admin are protected from deletion
+- password reset actions apply only to native users
+- unlimited quota can be entered with `-1`, `∞`, or `unlimited`
 
-Or add to your shell profile (~/.bashrc or ~/.zshrc):
+### Groups View
 
-```bash
-alias jhtoken='export JUPYTERHUB_TOKEN=$(kubectl -n jupyterhub get secret jupyterhub-admin-credentials -o go-template="{{index .data \"api-token\" | base64decode}}")'
-```
+The **Groups** page distinguishes among:
 
-## Web Interface (Admin Panel)
+- **GitHub-synced groups**
+- **system-managed groups**
+- **manual groups**
 
-Access the Admin Panel at `/hub/admin/users`.
+It supports:
 
-<!-- TODO: Add screenshot of the Admin Panel user list -->
-<!-- ![Admin Panel User List](./images/user-1-admin-panel.png) -->
+- creating manual groups
+- searching groups
+- editing group properties
+- reviewing group-to-resource mappings
+- adding and removing users from editable groups
+- manual GitHub sync through **Sync Now** when `custom.githubOrgName` is configured
 
-### User Table
+Current protection model:
 
-The user table displays:
-- **Username** - Click to view user details
-- **Admin** - Admin status badge
-- **Quota** - Current quota balance (if quota system enabled)
-- **Server** - Server status (Running/Stopped)
-- **Last Activity** - Last login or activity time
+- **system-managed groups** are read-only for membership edits
+- **GitHub-synced groups** are protected from deletion, but admins can still add extra users manually
 
-### Create User
+### Dashboard View
 
-1. Click **"Create Users"** button
-2. Enter usernames (one per line for batch creation)
-3. Choose password option:
-   - **Generate random passwords** (default) - Each user gets a unique password
-   - **Set password** - Enter a password for all users
-4. (Optional) Check **"Force password change on first login"**
-5. (Optional) Check **"Grant admin privileges"**
-6. Click **"Create Users"**
-7. After creation, copy the username/password table to share with users
+The **Dashboard** page provides:
 
-<!-- TODO: Add screenshot of Create User modal -->
-<!-- ![Create User Modal](./images/user-2-create-modal.png) -->
+- total users
+- active sessions
+- total usage minutes
+- active users this week
+- usage trends
+- resource distribution
+- top-user views
+- live active sessions
+- pending spawns
 
-### Edit User
+Use this as the primary operational view for current platform usage.
 
-1. Click the **pencil icon** on a user row to view user details
-2. Click **"Edit User"** to enter edit mode
-3. Available modifications:
-   - **Username** - Rename the user (warning: user must login with new name)
-   - **Admin status** - Grant or revoke admin privileges
-   - **Groups** - Assign user to groups
-4. Click **"Save Changes"**
+## CLI Scripts
 
-### Set Password
+The repository still includes CLI tools for bulk management.
 
-1. Click the **key icon** on a user row
-2. Enter new password, or click **"Generate"** for a random password
-3. (Optional) Check **"Force password change on next login"**
-4. Click **"Set Password"**
-5. After success, copy the password to share with the user
-
-<!-- TODO: Add screenshot of Set Password modal -->
-<!-- ![Set Password Modal](./images/user-3-password-modal.png) -->
-
-### Server Control
-
-- **Stop**: Click the red stop button to stop a user's running server
-- **Start**: Click the green play button to start a user's server
-
-### Batch Operations
-
-1. Select multiple users using checkboxes
-2. Available batch actions:
-   - **Start All Selected** - Start servers for selected users
-   - **Stop All Selected** - Stop servers for selected users
-   - **Set Quota** - Set quota for selected users (see [Quota System](./quota-system.md))
-
-<!-- TODO: Add screenshot of batch operations with multiple users selected -->
-<!-- ![Batch Operations](./images/user-4-batch-operations.png) -->
-
-### Search and Filter
-
-- Use the search box to filter users by username
-- Toggle "Only Active Servers" to show only users with running servers
-- Click column headers to sort by that column
-
-### Manage Groups
-
-Click **"Manage Groups"** to navigate to the group management page.
-
-## Script Usage
-
-### 1. Generate User Templates
-
-Create user list templates for batch operations.
+Common examples:
 
 ```bash
-# Generate 50 students
+# Generate a CSV template
 python scripts/generate_users_template.py --prefix student --count 50 --output users.csv
 
-# Generate AUP users (AUP01, AUP02, ...)
-python scripts/generate_users_template.py --prefix AUP --count 30 --start 1 --output aup_users.xlsx
-
-# Generate with 3-digit padding
-python scripts/generate_users_template.py --prefix student --count 100 --digits 3 --output users.csv
-
-# Custom usernames
-python scripts/generate_users_template.py --names alice bob charlie --output custom.csv
-```
-
-**Output format (CSV/Excel):**
-
-```text
-username,admin
-student01,false
-student02,false
-student03,false
-```
-
-### 2. Manage Users
-
-Perform batch operations via JupyterHub API.
-
-```bash
-# Create users from file
+# Create users from a file
 python scripts/manage_users.py create users.csv
 
-# List all users
+# List users
 python scripts/manage_users.py list
 
-# Export users to backup file
+# Export users
 python scripts/manage_users.py export backup.xlsx
 
-# Delete users (with confirmation)
-python scripts/manage_users.py delete remove_list.csv
+# Promote admins
+python scripts/manage_users.py set-admin teacher01 teacher02
 
-# Delete users (skip confirmation)
+# Revoke admin
+python scripts/manage_users.py set-admin --revoke student01
+
+# Set passwords from file
+python scripts/manage_users.py set-passwords users.csv --generate -o passwords_output.csv
+
+# Delete users
 python scripts/manage_users.py delete remove_list.csv --yes
 ```
 
-### 3. Manage Admin Privileges
+These scripts are still useful for class onboarding or spreadsheet-managed user lists.
 
-Grant or revoke admin privileges for existing users.
+## Recommended Operational Flow
 
-```bash
-# Grant admin to single user
-python scripts/manage_users.py set-admin teacher01
+### Single-Node
 
-# Grant admin to multiple users
-python scripts/manage_users.py set-admin teacher01 teacher02 teacher03
-
-# Grant admin from file
-python scripts/manage_users.py set-admin -f admins.csv
-
-# Revoke admin privileges
-python scripts/manage_users.py set-admin --revoke student01
-
-# Batch revoke
-python scripts/manage_users.py set-admin --revoke -f demote_list.csv
-```
-
-### 4. Set Passwords
-
-Set default passwords for users (requires kubectl access).
-
-> **Note:** For quota management commands (`set-quota`, `add-quota`, `list-quota`), see the [User Quota System](./quota-system.md) documentation.
+After config changes:
 
 ```bash
-# Set passwords from file with password column
-python scripts/manage_users.py set-passwords users_with_passwords.csv
-
-# Generate random passwords for users
-python scripts/manage_users.py set-passwords users.csv --generate -o passwords_output.csv
-
-# Set same default password for all users
-python scripts/manage_users.py set-passwords users.csv --generate --default-password "Welcome123"
-
-# Set passwords without forcing change on first login
-python scripts/manage_users.py set-passwords users.csv --no-force-change
+sudo ./auplc-installer rt upgrade
 ```
 
-## Common Workflows
-
-### Create New Users
+### Manual / Multi-Node Helm
 
 ```bash
-# Step 1: Generate template
-python scripts/generate_users_template.py \
-  --prefix student \
-  --count 50 \
-  --output new_students.csv
-
-# Step 2: (Optional) Edit CSV to customize
-# Edit new_students.csv if needed
-
-# Step 3: Create users in JupyterHub
-python scripts/manage_users.py create new_students.csv
+cd runtime
+helm upgrade --install jupyterhub ./chart \
+  -n jupyterhub --create-namespace \
+  -f values-multi-nodes.yaml
 ```
 
-**Expected output:**
-```
-✅ Connected to JupyterHub at http://localhost:30890
-📄 Loaded 50 users from new_students.csv
+## Related Pages
 
-🔄 Creating 50 users...
-  ✅ Created user: student01 (admin=False)
-  ✅ Created user: student02 (admin=False)
-  ...
-
-==================================================
-📊 Results:
-  ✅ Created: 50
-  ⚠️  Already exist: 0
-  ❌ Failed: 0
-==================================================
-```
-
-### Promote Users to Admin
-
-```bash
-# Single user
-python scripts/manage_users.py set-admin teacher01
-
-# Multiple users
-python scripts/manage_users.py set-admin teacher01 teacher02
-
-# From file (any CSV with username column)
-python scripts/manage_users.py set-admin -f new_admins.csv
-```
-
-### Backup Users
-
-```bash
-# Backup current users
-python scripts/manage_users.py export users_backup_$(date +%Y%m%d).xlsx
-
-# Later: restore users
-python scripts/manage_users.py create users_backup_20260113.xlsx
-```
-
-### Remove Users
-
-```bash
-# Step 1: Export current users
-python scripts/manage_users.py export all_users.csv
-
-# Step 2: Edit CSV, keep only users to delete
-# Create remove_list.csv with usernames to delete
-
-# Step 3: Delete users
-python scripts/manage_users.py delete remove_list.csv
-```
-
-## File Format
-
-Both scripts support **CSV** and **Excel** (.xlsx) formats.
-
-**Required column:**
-- `username` - Username to create/delete
-
-**Optional columns:**
-- `admin` - Set to `true` for admin users (default: `false`)
-- `password` - Password for set-passwords command
-
-**Example CSV:**
-
-```text
-username,admin
-student01,false
-student02,false
-teacher01,true
-```
-
-## Troubleshooting
-
-### Connection Issues
-
-**Symptom:** "Connection refused"
-
-**Solutions:**
-```bash
-# Check hub is running
-kubectl --namespace=jupyterhub get pods
-
-# For local dev
-export JUPYTERHUB_URL="http://localhost:30890"
-
-# For production
-export JUPYTERHUB_URL="https://your-domain.com"
-
-# Test connection
-curl $JUPYTERHUB_URL/hub/api/
-```
-
-### Authentication Issues
-
-**Symptom:** "Authentication failed"
-
-**Solutions:**
-```bash
-# Verify token is set
-echo $JUPYTERHUB_TOKEN
-
-# Test token
-curl -X GET $JUPYTERHUB_URL/hub/api/ \
-  -H "Authorization: token $JUPYTERHUB_TOKEN"
-```
-
-### Common Errors
-
-**"User already exists"**
-- This is just a warning, not an error
-- The user is already in the system
-
-**"File must contain 'username' column"**
-- Ensure your file has a `username` column header
-
-## Notes
-
-- **Auto-Admin**: Initial admin is created automatically on helm install
-- **Additional Admins**: Use `set-admin` command or Admin Panel
-- **First Login**: Native users must set their password on first login
-- **Safety**: Delete operations ask for confirmation (use `--yes` to skip)
-- **Batch Size**: No limit, but larger batches (1000+) may be slow
-
-## Help
-
-Get detailed help for each script:
-
-```bash
-python scripts/generate_users_template.py --help
-python scripts/manage_users.py --help
-```
+- [Authentication Guide](authentication-guide.md)
+- [User Quota System](quota-system.md)
+- [Configuration Reference](configuration-reference.md)

--- a/source/user-guide/admin-manual.md
+++ b/source/user-guide/admin-manual.md
@@ -1,128 +1,86 @@
-# Admin Manual — JupyterHub Components and Workflows
+# Admin Manual
 
-This page describes advanced implementation details and workflows. For day-to-day configuration (auth, images, quotas, storage), use the [Configuration Reference](../jupyterhub/configuration-reference.md) and [Single-Node Deployment](../installation/single-node.md). Single-node deployments can use `sudo ./auplc-installer rt upgrade` from the repo root; multi-node or custom Helm deployments use `bash scripts/helm_upgrade.bash` from the **repo root**.
+This page summarizes the current administrator-facing workflows.
 
-## Multi-login Authenticator
+For value-by-value configuration, use the [Configuration Reference](../jupyterhub/configuration-reference.md).
 
-The multi-login system uses `MultiAuthenticator` to combine multiple authentication methods on a single login page:
+## Admin Surfaces
 
-```python
-c.MultiAuthenticator.authenticators = [
-    {
-        "authenticator_class": CustomGitHubOAuthenticator,
-        "url_prefix": "/github",
-    },
-    {
-        "authenticator_class": CustomFirstUseAuthenticator,
-        "url_prefix": "/local",
-    },
-]
+### Web Admin Console
+
+The web admin console lives at `/hub/admin` and includes:
+
+- **Users** - create users, edit admin status, reset passwords, set quotas, start/stop servers, inspect usage
+- **Groups** - review group members, manage manual groups, inspect protected GitHub/system groups, review resource mappings
+- **Dashboard** - usage charts, active sessions, pending spawns, and top-user/resource views
+
+### CLI / API-Oriented Scripts
+
+The repository still includes script-based user management for batch workflows. Use these when you need spreadsheet-driven or repeatable operations.
+
+## Daily Operations
+
+### Apply Configuration Changes
+
+**Single-node:**
+
+```bash
+sudo ./auplc-installer rt upgrade
 ```
 
-- `CustomGitHubOAuthenticator` handles GitHub OAuth login
-- `CustomFirstUseAuthenticator` handles local account login (each user has their own password)
-- The `url_prefix` distinguishes login methods, and the callback URL is `/hub/<method>/oauth_login`
+**Manual / multi-node Helm:**
 
-To enable multi-login, set `custom.authMode: "multi"` in `runtime/values.yaml`. The Hub image includes `jupyterhub-multiauthenticator` and `jupyterhub-firstuseauthenticator` as dependencies.
+```bash
+cd runtime
+helm upgrade --install jupyterhub ./chart \
+  -n jupyterhub --create-namespace \
+  -f values-multi-nodes.yaml
+```
 
-## RemoteLabSpawner
+### Rebuild Images After Image Changes
 
-The spawner allocates resources based on user permissions (e.g., GitHub team membership). It generates a resource selection page where users choose their environment. The spawn page is a React application located at `runtime/hub/frontend/apps/spawn/`.
+```bash
+sudo ./auplc-installer img build
+sudo ./auplc-installer rt reinstall
+```
 
-# Workflows
+## Common Admin Tasks
 
-## Workflow 1: Apply config changes
+### Create Native Users
 
-1. Edit `runtime/values.yaml`
-2. From the **repo root**, run one of:
-   ```bash
-   # Single-node (with auplc-installer)
-   sudo ./auplc-installer rt upgrade
+Use the **Users** page in `/hub/admin`, or use the existing CLI scripts for bulk import.
 
-   # Multi-node / custom Helm
-   bash scripts/helm_upgrade.bash
-   ```
-3. Check status with `k9s` or `kubectl get pods -n jupyterhub`
+### Reset Passwords
 
-## Workflow 2: Add a new resource image
+Native-user passwords can be reset from the admin console. This is a web UI feature now, not only a script workflow.
 
-1. Create a new folder under `dockerfiles/`, e.g., `dockerfiles/Courses/NewImage/`
-2. Create a `Dockerfile` and `build.sh`. The base image is typically `ubuntu:24.04` with a tarball ROCm install (see `dockerfiles/Base/` for reference).
-3. Build and test the image locally before pushing:
-   ```bash
-   docker build -f dockerfiles/Courses/NewImage/Dockerfile -t ghcr.io/amdresearch/auplc-newimage:latest .
-   ```
-4. Push to the container registry (requires push permissions to `ghcr.io/amdresearch`).
-5. Add the new image to `runtime/values.yaml`:
-   ```yaml
-   custom:
-     resources:
-       images:
-         NewImage: "ghcr.io/amdresearch/auplc-newimage:latest"
-       requirements:
-         NewImage:
-           cpu: "4"
-           memory: "16Gi"
-           amd.com/gpu: "1"
-     teams:
-       mapping:
-         gpu:
-           - NewImage  # Add to appropriate team(s)
-   ```
-6. Add the image as a prepuller in `runtime/values.yaml`:
-   ```yaml
-   prePuller:
-     extraImages:
-       auplc-newimage:
-         name: ghcr.io/amdresearch/auplc-newimage
-         tag: latest
-   ```
-7. Deploy:
-   ```bash
-   sudo ./auplc-installer rt upgrade
-   # or: bash scripts/helm_upgrade.bash  (from repo root)
-   ```
-8. For new images, prepulling may take time depending on network speed. Monitor with `k9s`. If a node halts, delete and restart prepuller pods. If problems persist, SSH into the node and restart K3s.
-9. If timeout causes `pending-upgraded` failure, check past versions with `helm history jupyterhub -n jupyterhub`, rollback with `helm rollback jupyterhub <version> -n jupyterhub`, then redeploy.
+### Manage Groups
 
-## Workflow 3: Update an existing image
+The **Groups** page distinguishes among:
 
-1. Update the image tag in `build.sh` and `runtime/values.yaml` (under `custom.resources.images` and `prePuller.extraImages`).
-2. Build and push to the registry.
-3. Deploy:
-   ```bash
-   sudo ./auplc-installer rt upgrade
-   ```
-   If there are problems, refer to steps 8-9 in Workflow 2.
+- manually managed groups
+- system-managed groups
+- GitHub-synced groups
 
-## Workflow 4: Edit resource limits or team permissions
+GitHub-synced and system-managed groups have protection rules; treat them differently from ad hoc manual groups.
 
-1. Edit `runtime/values.yaml`:
-   - `custom.resources.requirements` — CPU, memory, GPU limits per resource
-   - `custom.teams.mapping` — which teams can access which resources
-2. Deploy:
-   ```bash
-   sudo ./auplc-installer rt upgrade
-   ```
+### Manage Quota
 
-## Workflow 5: Change login settings
+If quota is enabled, administrators can:
 
-1. Set `custom.authMode` in `runtime/values.yaml`:
-   - `"auto-login"` — no credentials required (single-node dev)
-   - `"dummy"` — any username/password accepted (testing)
-   - `"github"` — GitHub OAuth only
-   - `"multi"` — GitHub OAuth + local accounts
-2. For GitHub OAuth, configure `hub.config.GitHubOAuthenticator` in `runtime/values.yaml`. See [GitHub App Setup](../jupyterhub/github-oauth-setup.md).
-3. For local accounts, each user has their own password (set on first login or via batch scripts). See [Authentication Guide](../jupyterhub/authentication-guide.md).
-4. Deploy:
-   ```bash
-   sudo ./auplc-installer rt upgrade
-   ```
+- edit user balances inline
+- batch update balances
+- grant unlimited quota
+- inspect usage detail from the admin UI
 
-## Workflow 6: Change announcement on login page
+See [User Quota System](../jupyterhub/quota-system.md) for details.
 
-1. Edit the announcement HTML in `runtime/values.yaml` under `hub.extraFiles.announcement.txt.stringData`.
-2. Deploy:
-   ```bash
-   sudo ./auplc-installer rt upgrade
-   ```
+### Update Login / Home Announcement
+
+Edit `hub.extraFiles.announcement.txt.stringData` in your values file, then redeploy.
+
+## Operational Notes
+
+- The default checked-in single-node values use `auto-login`; many auth and admin behaviors become more relevant once you switch to `github` or `multi` mode.
+- Admin bootstrap is optional; it only happens if `custom.adminUser.enabled` is turned on.
+- Multi-node deployments should use the standalone `values-multi-nodes.yaml` file rather than assuming the single-node defaults apply.


### PR DESCRIPTION
## Summary
- refresh the core docs pages to match the current platform behavior instead of outdated historical flows
- rewrite install, Hub, auth, admin, user management, and quota guidance around the current code paths and admin UI
- rebuild the Sphinx site and verify the updated pages in a browser preview

## Verification
- make html
- manual browser check for updated pages under introduction, installation, jupyterhub, and user-guide

## Notes
- kept the existing unrelated Sphinx warning for `source/installation/includes/selector-quickstart-gpu.rst` not being included in any toctree
- browser console still shows the local preview `favicon.ico` 404