### PR TITLE
Update ROCm base image to 7.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ newgrp docker
 sudo apt install build-essential
 ```
 
-> **Kernel note**: The OEM kernel package follows AMD ROCm's Ryzen APU installation guidance for Ubuntu 24.04. See the [ROCm installation guide for Ryzen APUs](https://rocm.docs.amd.com/en/7.12.0-preview/install/rocm.html?fam=ryzen&gpu=max-pro-395&os=ubuntu&os-version=24.04&i=pkgman) for details.
+> **Kernel note**: The OEM kernel package follows AMD ROCm's Ryzen APU installation guidance for Ubuntu 24.04. See the [ROCm installation guide for Ryzen APUs](https://rocm.docs.amd.com/en/7.12.0/install/rocm.html?fam=ryzen&gpu=max-pro-395&os=ubuntu&os-version=24.04&i=pkgman) for details.
 >
 > **Docker note**: See [Docker Post-installation Steps](https://docs.docker.com/engine/install/linux-postinstall/) and [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/) for details.
 

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -39,7 +39,7 @@ ARG NB_GID=100
 # The tarball and wheel URLs are derived from GPU_TARGET automatically.
 # Use ROCM_TARBALL_URL / PYTORCH_INDEX_URL to override for edge cases.
 ARG GPU_TARGET=gfx1151
-ARG ROCM_VERSION=7.11.0
+ARG ROCM_VERSION=7.12.0
 ARG PYTORCH_VERSION=2.9.1
 ARG TORCHVISION_VERSION=0.24.0
 ARG TORCHAUDIO_VERSION=2.9.0
@@ -94,7 +94,7 @@ RUN mkdir -p /etc/apt/keyrings && \
 RUN echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages/ubuntu2404 stable main' \
     > /etc/apt/sources.list.d/rocm.list
 
-# Install ROCm from apt (package name uses GPU_TARGET, e.g. amdrocm7.11-gfx110X-all)
+# Install ROCm from apt (package name uses GPU_TARGET, e.g. amdrocm7.12-gfx110X-all)
 # After install, create standard /opt/rocm/{bin,lib,include} symlinks — the amdrocm
 # packages install into /opt/rocm/core-<ver>/ without the standard top-level layout,
 # so hipcc and device bitcode are not found via PATH / LD_LIBRARY_PATH otherwise.

--- a/dockerfiles/Base/README.md
+++ b/dockerfiles/Base/README.md
@@ -24,6 +24,7 @@ SOFTWARE.
 ## GPU Base Image (`Dockerfile.rocm`)
 
 Multi-target ROCm GPU base image. Set `GPU_TARGET` to build for any supported architecture.
+`Dockerfile.rocm` defaults to ROCm 7.12.0 unless `ROCM_VERSION` is overridden at build time.
 
 ### Supported Targets
 
@@ -36,7 +37,7 @@ Multi-target ROCm GPU base image. Set `GPU_TARGET` to build for any supported ar
 | gfx120x       | RDNA 4   | gfx1201 (dGPU: RX 9070 XT, R9700, RX 9600 GRE, …) | gfx120X-all |
 
 The `GPU_TARGET` value is the short name used by the AMD apt repo
-(`amdrocm7.11-<GPU_TARGET>`) and as the image-tag suffix. The pip wheel index
+(`amdrocm7.12-<GPU_TARGET>`) and as the image-tag suffix. The pip wheel index
 at <https://repo.amd.com/rocm/whl/> uses the "long" `gfxNNNX-all` path for
 the generic RDNA 3 / RDNA 4 buckets; `Dockerfile.rocm` maps short → long
 automatically. CI passes `PYTORCH_WHL_TARGET` explicitly (see


### PR DESCRIPTION
## Summary
- Bump the ROCm base image default from 7.11.0 to 7.12.0.
- Align the base image documentation and top-level ROCm guide link with 7.12.

## Validation
- `docker build --check -f dockerfiles/Base/Dockerfile.rocm dockerfiles/Base`
- `git diff --check`
- Targeted grep confirmed no remaining `7.11.0`, `amdrocm7.11`, or `7.12.0-preview` references in the changed ROCm docs/Dockerfile scope.

Jira: AUPPM-66