### PR TITLE
fix(home): show quota balance in minutes

### DIFF
--- a/runtime/hub/frontend/apps/home/src/App.tsx
+++ b/runtime/hub/frontend/apps/home/src/App.tsx
@@ -412,7 +412,7 @@ function App() {
               {quota?.enabled && (
                 <span className="lb-quota-inline">
                   {" · Quota: "}
-                  {quota.unlimited ? "Unlimited" : `${quota.balance}h remaining`}
+                  {quota.unlimited ? "Unlimited" : `${quota.balance} min remaining`}
                 </span>
               )}
             </div>


### PR DESCRIPTION
## Summary
- Update the homepage quota label to show remaining balance in minutes instead of hours.
- Keep unlimited quota display unchanged.

## Verification
- pnpm --filter @auplc/home run build
- pnpm --filter @auplc/home run lint
- LSP diagnostics on runtime/hub/frontend/apps/home/src/App.tsx