### PR TITLE
fix(installer): use ROCm GPU agent target for image tags

### DIFF
--- a/auplc_installer/gpu.py
+++ b/auplc_installer/gpu.py
@@ -20,7 +20,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from auplc_installer.util import command_exists, log, run_capture
+from auplc_installer.util import InstallerError, command_exists, log, run_capture
 
 # ---------------------------------------------------------------------------
 # Curated SKU table  — keep accel_key in sync with runtime/values.yaml
@@ -86,14 +86,22 @@ _GFX_FALLBACK: dict[str, SkuRow] = {
 }
 
 
+def normalise_gpu_type_key(input_key: str) -> str:
+    """Normalise CLI/detected GPU type aliases to fallback-table keys."""
+    key = input_key.strip().lower().replace("_", "-")
+    m = re.fullmatch(r"gfx-?([0-9]+)", key)
+    if m:
+        return f"gfx{m.group(1)}"
+    return key
+
+
 def resolve_gpu_config(input_key: str) -> SkuRow:
     """Map a user-supplied GPU type or detected gfx family to a SKU row.
 
     Raises :class:`InstallerError` for unsupported inputs.
     """
-    from auplc_installer.util import InstallerError
-
-    row = _GFX_FALLBACK.get(input_key)
+    key = normalise_gpu_type_key(input_key)
+    row = _GFX_FALLBACK.get(key)
     if row is None:
         raise InstallerError(
             f"Unsupported GPU type: {input_key}\n"
@@ -295,11 +303,29 @@ def sku_for_product_name(product: str) -> SkuRow:
     return PRODUCT_NAME_TO_SKU.get(product) or _synthesise_uncurated_row(product)
 
 
-def append_product(cfg: GpuConfig, product: str) -> None:
+def sku_for_detected_product(product: str, gfx_family: str = "") -> SkuRow:
+    """Resolve a detected product, using gfx family before generic fallback.
+
+    Some ROCm/sysfs stacks report a generic marketing name for Strix-class
+    APUs. When a precise gfx family is available, prefer it over the generic
+    future-GPU fallback so single-node local builds keep the correct image tag.
+    """
+    row = PRODUCT_NAME_TO_SKU.get(product)
+    if row is not None:
+        return row
+    if gfx_family:
+        try:
+            return resolve_gpu_config(gfx_family)
+        except InstallerError:
+            pass
+    return _synthesise_uncurated_row(product)
+
+
+def append_product(cfg: GpuConfig, product: str, gfx_family: str = "") -> None:
     """Resolve a product name and append it as an SKU entry."""
     if not product:
         return
-    accel_key, gpu_target, env, rate, display = sku_for_product_name(product)
+    accel_key, gpu_target, env, rate, display = sku_for_detected_product(product, gfx_family)
     cfg.append(
         SkuEntry(
             accel_key=accel_key,
@@ -340,18 +366,21 @@ def detect_and_configure_gpu(cfg: GpuConfig, gpu_type_override: str = "") -> Non
     cfg.gpu_product_name = ""
 
     names = detect_gpu_product_names()
+    detected_gfx = ""
+    if len(names) == 1 and names[0] not in PRODUCT_NAME_TO_SKU:
+        detected_gfx = detect_gpu_gfx_family() or ""
     if names:
         log("Detected GPU product name(s) from host:")
         for name in names:
             log(f"  - {name}")
-            append_product(cfg, name)
+            append_product(cfg, name, detected_gfx)
 
     if not cfg.skus:
         if gpu_type_override:
             log(f"Using GPU type override: {gpu_type_override}")
             input_key = gpu_type_override
         else:
-            gfx = detect_gpu_gfx_family()
+            gfx = detected_gfx or detect_gpu_gfx_family()
             if gfx:
                 log(f"Detected GPU: {gfx}")
                 input_key = gfx

--- a/auplc_installer/gpu.py
+++ b/auplc_installer/gpu.py
@@ -34,6 +34,7 @@ SkuRow = tuple[str, str, str, int, str]
 PRODUCT_NAME_TO_SKU: dict[str, SkuRow] = {
     "AMD_Radeon_780M_Graphics": ("phx", "gfx110x", "11.0.0", 2, "AMD Radeon 780M (Phoenix Point iGPU)"),
     "AMD_Radeon_890M_Graphics": ("strix", "gfx1150", "", 2, "AMD Radeon 890M (Strix Point iGPU)"),
+    "AMD_Ryzen_AI_9_HX_370_w_Radeon_890M": ("strix", "gfx1150", "", 2, "AMD Radeon 890M (Strix Point iGPU)"),
     "AMD_Radeon_8060S_Graphics": ("strix-halo", "gfx1151", "", 3, "AMD Radeon 8060S (Strix Halo iGPU)"),
     "AMD_Radeon_9070XT": ("9070xt", "gfx120x", "", 4, "AMD Radeon RX 9070 XT"),
     "AMD_Radeon_RX_9070_XT": ("9070xt", "gfx120x", "", 4, "AMD Radeon RX 9070 XT"),
@@ -495,7 +496,7 @@ def refine_gpu_config_from_node_labels(cfg: GpuConfig) -> None:
 
     cfg.reset()
     for n in names:
-        append_product(cfg, n)
+        append_product(cfg, n, pinned_target)
 
     log("Refreshed GPU SKUs from node labels (ROCm labeller is authoritative):")
     log("  product names    : " + ", ".join(names))

--- a/auplc_installer/gpu.py
+++ b/auplc_installer/gpu.py
@@ -34,7 +34,6 @@ SkuRow = tuple[str, str, str, int, str]
 PRODUCT_NAME_TO_SKU: dict[str, SkuRow] = {
     "AMD_Radeon_780M_Graphics": ("phx", "gfx110x", "11.0.0", 2, "AMD Radeon 780M (Phoenix Point iGPU)"),
     "AMD_Radeon_890M_Graphics": ("strix", "gfx1150", "", 2, "AMD Radeon 890M (Strix Point iGPU)"),
-    "AMD_Ryzen_AI_9_HX_370_w_Radeon_890M": ("strix", "gfx1150", "", 2, "AMD Radeon 890M (Strix Point iGPU)"),
     "AMD_Radeon_8060S_Graphics": ("strix-halo", "gfx1151", "", 3, "AMD Radeon 8060S (Strix Halo iGPU)"),
     "AMD_Radeon_9070XT": ("9070xt", "gfx120x", "", 4, "AMD Radeon RX 9070 XT"),
     "AMD_Radeon_RX_9070_XT": ("9070xt", "gfx120x", "", 4, "AMD Radeon RX 9070 XT"),
@@ -130,6 +129,77 @@ def normalise_product_name(raw: str) -> str:
     return s.strip("_")
 
 
+def _append_unique(out: list[str], seen: set[str], value: str) -> None:
+    if value and value not in seen:
+        seen.add(value)
+        out.append(value)
+
+
+def _rocminfo_gpu_agent_records(text: str) -> list[tuple[str, list[str]]]:
+    """Return ``(marketing_name, gfx_targets)`` records for GPU agents.
+
+    ROCm reports the GPU agent ``Name`` from the ISA processor target and the
+    ``Marketing Name`` from a separate product/branding field. Keep the parser
+    scoped to ``Device Type: GPU`` blocks so CPU/APU marketing names do not
+    influence image-tag selection.
+    """
+    records: list[tuple[str, list[str]]] = []
+    in_agent = False
+    in_isa = False
+    device_type = ""
+    agent_name = ""
+    marketing = ""
+    isa_targets: list[str] = []
+
+    def gfx_from(value: str) -> str:
+        m = re.search(r"\bgfx[0-9]{3,4}\b", value)
+        return m.group(0) if m else ""
+
+    def flush() -> None:
+        if not in_agent or device_type != "GPU":
+            return
+        targets: list[str] = []
+        seen_targets: set[str] = set()
+        for target in isa_targets:
+            _append_unique(targets, seen_targets, target)
+        _append_unique(targets, seen_targets, gfx_from(agent_name))
+        records.append((marketing, targets))
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if re.match(r"^Agent\s+\d+\b", line):
+            flush()
+            in_agent = True
+            in_isa = False
+            device_type = ""
+            agent_name = ""
+            marketing = ""
+            isa_targets = []
+            continue
+        if not in_agent:
+            continue
+        if line.startswith("ISA Info:"):
+            in_isa = True
+            continue
+        if line.startswith("Device Type:"):
+            device_type = line.split(":", 1)[1].strip()
+            continue
+        if line.startswith("Marketing Name:"):
+            marketing = line.split(":", 1)[1].strip()
+            continue
+        if line.startswith("Name:"):
+            value = line.split(":", 1)[1].strip()
+            if in_isa:
+                target = gfx_from(value)
+                if target:
+                    isa_targets.append(target)
+            elif not agent_name:
+                agent_name = value
+
+    flush()
+    return records
+
+
 def detect_gpu_product_names() -> list[str]:
     """All distinct AMD GPU product names on this host (labeller-normalised)."""
     out: list[str] = []
@@ -143,22 +213,9 @@ def detect_gpu_product_names() -> list[str]:
             text = res.stdout or ""
         except Exception:
             text = ""
-        marketing = ""
-        for raw_line in text.splitlines():
-            line = raw_line.strip()
-            m = re.match(r"^Marketing Name:\s*(.*)$", line)
-            if m:
-                marketing = m.group(1).strip()
-                continue
-            m = re.match(r"^Device Type:\s*(.*)$", line)
-            if m:
-                devtype = m.group(1).strip()
-                if devtype == "GPU" and marketing:
-                    name = normalise_product_name(marketing)
-                    if name and name not in seen:
-                        seen.add(name)
-                        out.append(name)
-                marketing = ""
+        for marketing, _ in _rocminfo_gpu_agent_records(text):
+            name = normalise_product_name(marketing)
+            _append_unique(out, seen, name)
 
     # 2. amdgpu sysfs (no ROCm dependency).
     for f in sorted(Path("/sys/class/drm").glob("card*/device/product_name")):
@@ -184,10 +241,9 @@ def detect_gpu_gfx_family() -> str | None:
     if command_exists("rocminfo"):
         try:
             res = run_capture(["rocminfo"], check=False, stderr_to_stdout=True)
-            for line in (res.stdout or "").splitlines():
-                m = re.search(r"gfx[0-9]+", line)
-                if m:
-                    return m.group(0)
+            for _, targets in _rocminfo_gpu_agent_records(res.stdout or ""):
+                if targets:
+                    return targets[0]
         except Exception:
             pass
 

--- a/tests/installer/test_gpu.py
+++ b/tests/installer/test_gpu.py
@@ -11,6 +11,7 @@ the installer reads from.
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
 from auplc_installer.gpu import (
     _GFX_FALLBACK,
@@ -19,9 +20,12 @@ from auplc_installer.gpu import (
     GpuConfig,
     SkuEntry,
     append_product,
+    detect_and_configure_gpu,
     is_curated_sku,
+    normalise_gpu_type_key,
     normalise_product_name,
     resolve_gpu_config,
+    sku_for_detected_product,
     sku_for_product_name,
 )
 from auplc_installer.util import InstallerError
@@ -77,9 +81,37 @@ class ResolveGpuConfigTests(unittest.TestCase):
         accel_key, gpu_target, _, _, _ = resolve_gpu_config("gfx1151")
         self.assertEqual((accel_key, gpu_target), ("strix-halo", "gfx1151"))
 
+    def test_hyphenated_gfx_alias(self) -> None:
+        accel_key, gpu_target, _, _, _ = resolve_gpu_config("gfx-1150")
+        self.assertEqual((accel_key, gpu_target), ("strix", "gfx1150"))
+
+    def test_normalise_gpu_type_key(self) -> None:
+        self.assertEqual(normalise_gpu_type_key(" GFX-1150 "), "gfx1150")
+        self.assertEqual(normalise_gpu_type_key("strix_halo"), "strix-halo")
+
     def test_unsupported_input_raises(self) -> None:
         with self.assertRaises(InstallerError):
             resolve_gpu_config("totally-not-a-gpu")
+
+
+class DetectedProductFallbackTests(unittest.TestCase):
+    def test_unknown_product_uses_detected_gfx_family_before_generic_fallback(self) -> None:
+        row = sku_for_detected_product("AMD_Radeon_Graphics", "gfx1150")
+        self.assertEqual(row[0], "strix")
+        self.assertEqual(row[1], "gfx1150")
+
+    def test_unknown_product_without_gfx_family_keeps_generic_fallback(self) -> None:
+        row = sku_for_detected_product("AMD_Radeon_Graphics")
+        self.assertEqual(row[1], "gfx120x")
+
+    @patch("auplc_installer.gpu.detect_gpu_gfx_family", return_value="gfx1150")
+    @patch("auplc_installer.gpu.detect_gpu_product_names", return_value=["AMD_Radeon_Graphics"])
+    def test_detect_and_configure_uses_gfx_for_generic_single_product_name(self, *_: object) -> None:
+        cfg = GpuConfig()
+        detect_and_configure_gpu(cfg)
+        self.assertEqual(cfg.accel_key, "strix")
+        self.assertEqual(cfg.gpu_target, "gfx1150")
+        self.assertEqual(cfg.gpu_product_name, "AMD_Radeon_Graphics")
 
 
 class FallbackQuotaRateAlignmentTests(unittest.TestCase):

--- a/tests/installer/test_gpu.py
+++ b/tests/installer/test_gpu.py
@@ -24,6 +24,7 @@ from auplc_installer.gpu import (
     is_curated_sku,
     normalise_gpu_type_key,
     normalise_product_name,
+    refine_gpu_config_from_node_labels,
     resolve_gpu_config,
     sku_for_detected_product,
     sku_for_product_name,
@@ -48,12 +49,23 @@ class NormaliseProductNameTests(unittest.TestCase):
         self.assertEqual(normalise_product_name(""), "")
         self.assertEqual(normalise_product_name("   "), "")
 
+    def test_normalises_ryzen_ai_890m_marketing_name(self) -> None:
+        self.assertEqual(
+            normalise_product_name("AMD Ryzen AI 9 HX 370 w/ Radeon 890M"),
+            "AMD_Ryzen_AI_9_HX_370_w_Radeon_890M",
+        )
+
 
 class CuratedSkuLookupTests(unittest.TestCase):
     def test_known_product_name_resolves_to_curated_row(self) -> None:
         row = sku_for_product_name("AMD_Radeon_8060S_Graphics")
         self.assertEqual(row[0], "strix-halo")
         self.assertEqual(row[1], "gfx1151")
+
+    def test_ryzen_ai_890m_marketing_name_resolves_to_strix(self) -> None:
+        row = sku_for_product_name("AMD_Ryzen_AI_9_HX_370_w_Radeon_890M")
+        self.assertEqual(row[0], "strix")
+        self.assertEqual(row[1], "gfx1150")
 
     def test_unknown_product_name_synthesises_row(self) -> None:
         row = sku_for_product_name("AMD_Mystery_GPU")
@@ -112,6 +124,23 @@ class DetectedProductFallbackTests(unittest.TestCase):
         self.assertEqual(cfg.accel_key, "strix")
         self.assertEqual(cfg.gpu_target, "gfx1150")
         self.assertEqual(cfg.gpu_product_name, "AMD_Radeon_Graphics")
+
+    @patch("auplc_installer.gpu._read_gpu_product_names_from_node_labels", return_value=["AMD_Radeon_Graphics"])
+    def test_refinement_preserves_existing_gfx_for_generic_product_name(self, *_: object) -> None:
+        cfg = GpuConfig()
+        cfg.append(
+            SkuEntry(
+                accel_key="strix",
+                product_name="AMD_Radeon_Graphics",
+                gpu_target="gfx1150",
+                accel_env="",
+                quota_rate=2,
+                display_name="",
+            )
+        )
+        refine_gpu_config_from_node_labels(cfg)
+        self.assertEqual(cfg.accel_key, "strix")
+        self.assertEqual(cfg.gpu_target, "gfx1150")
 
 
 class FallbackQuotaRateAlignmentTests(unittest.TestCase):

--- a/tests/installer/test_gpu.py
+++ b/tests/installer/test_gpu.py
@@ -11,6 +11,7 @@ the installer reads from.
 from __future__ import annotations
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from auplc_installer.gpu import (
@@ -19,8 +20,11 @@ from auplc_installer.gpu import (
     PRODUCT_NAME_TO_SKU,
     GpuConfig,
     SkuEntry,
+    _rocminfo_gpu_agent_records,
     append_product,
     detect_and_configure_gpu,
+    detect_gpu_gfx_family,
+    detect_gpu_product_names,
     is_curated_sku,
     normalise_gpu_type_key,
     normalise_product_name,
@@ -56,16 +60,44 @@ class NormaliseProductNameTests(unittest.TestCase):
         )
 
 
+ROCMINFO_WITH_STRIX_CPU_AND_GPU = """
+Agent 1
+Name:                    AMD Ryzen AI 9 HX 370 w/ Radeon 890M
+Marketing Name:          AMD Ryzen AI 9 HX 370 w/ Radeon 890M
+Device Type:             CPU
+ISA Info:
+Agent 2
+Name:                    gfx1150
+Marketing Name:          AMD Radeon Graphics
+Device Type:             GPU
+ISA Info:
+ISA 1
+Name:                    amdgcn-amd-amdhsa--gfx1150
+ISA 2
+Name:                    amdgcn-amd-amdhsa--gfx11-generic
+"""
+
+
+class RocminfoGpuAgentParserTests(unittest.TestCase):
+    def test_records_ignore_cpu_marketing_name_and_keep_gpu_gfx_target(self) -> None:
+        self.assertEqual(_rocminfo_gpu_agent_records(ROCMINFO_WITH_STRIX_CPU_AND_GPU), [("AMD Radeon Graphics", ["gfx1150"])])
+
+    @patch("auplc_installer.gpu.command_exists", return_value=True)
+    @patch("auplc_installer.gpu.run_capture", return_value=SimpleNamespace(stdout=ROCMINFO_WITH_STRIX_CPU_AND_GPU))
+    def test_detect_gpu_product_names_reads_gpu_agent_marketing_only(self, *_: object) -> None:
+        self.assertEqual(detect_gpu_product_names(), ["AMD_Radeon_Graphics"])
+
+    @patch("auplc_installer.gpu.command_exists", return_value=True)
+    @patch("auplc_installer.gpu.run_capture", return_value=SimpleNamespace(stdout=ROCMINFO_WITH_STRIX_CPU_AND_GPU))
+    def test_detect_gpu_gfx_family_prefers_gpu_agent_target(self, *_: object) -> None:
+        self.assertEqual(detect_gpu_gfx_family(), "gfx1150")
+
+
 class CuratedSkuLookupTests(unittest.TestCase):
     def test_known_product_name_resolves_to_curated_row(self) -> None:
         row = sku_for_product_name("AMD_Radeon_8060S_Graphics")
         self.assertEqual(row[0], "strix-halo")
         self.assertEqual(row[1], "gfx1151")
-
-    def test_ryzen_ai_890m_marketing_name_resolves_to_strix(self) -> None:
-        row = sku_for_product_name("AMD_Ryzen_AI_9_HX_370_w_Radeon_890M")
-        self.assertEqual(row[0], "strix")
-        self.assertEqual(row[1], "gfx1150")
 
     def test_unknown_product_name_synthesises_row(self) -> None:
         row = sku_for_product_name("AMD_Mystery_GPU")

--- a/tests/installer/test_gpu.py
+++ b/tests/installer/test_gpu.py
@@ -80,7 +80,9 @@ Name:                    amdgcn-amd-amdhsa--gfx11-generic
 
 class RocminfoGpuAgentParserTests(unittest.TestCase):
     def test_records_ignore_cpu_marketing_name_and_keep_gpu_gfx_target(self) -> None:
-        self.assertEqual(_rocminfo_gpu_agent_records(ROCMINFO_WITH_STRIX_CPU_AND_GPU), [("AMD Radeon Graphics", ["gfx1150"])])
+        self.assertEqual(
+            _rocminfo_gpu_agent_records(ROCMINFO_WITH_STRIX_CPU_AND_GPU), [("AMD Radeon Graphics", ["gfx1150"])]
+        )
 
     @patch("auplc_installer.gpu.command_exists", return_value=True)
     @patch("auplc_installer.gpu.run_capture", return_value=SimpleNamespace(stdout=ROCMINFO_WITH_STRIX_CPU_AND_GPU))


### PR DESCRIPTION
## Summary
- Parse `rocminfo` GPU agent blocks and prefer the runtime gfx target from GPU agent `Name:` / ISA `Name:` (for example `gfx1150`) when choosing installer image tags.
- Keep marketing/product names as auxiliary SKU metadata only; unknown or generic GPU marketing names no longer force the installer into the generic `gfx120x` fallback when a precise gfx target is available.
- Preserve the detected gfx target during node-label refinement so a generic labeller product name does not revert a correct `gfx1150` install back to `gfx120x`.

## Root Cause
ROCm reports agent `Name` and `Marketing Name` from different runtime fields. For GPU agents, `Name:` is derived from the ISA processor target (for example `gfx1150`), while `Marketing Name:` is product branding and can vary across ROCm/kernel/firmware versions. On Ryzen AI HX 370 / Radeon 890M systems, the GPU agent can expose `gfx1150` while the marketing name is generic or otherwise not present in the installer SKU table. The previous installer path let the unknown marketing-name result take precedence and synthesized a `gfx120x` image target.

## Implementation Notes
- The parser is scoped to `Device Type: GPU` agent blocks so CPU/APU marketing names such as `AMD Ryzen AI 9 HX 370 w/ Radeon 890M` do not influence image tag selection.
- Within a GPU agent, the parser accepts gfx targets from ISA names such as `amdgcn-amd-amdhsa--gfx1150` and falls back to the agent-level `Name: gfx1150`.
- Product-name mapping remains available for curated SKU metadata, but precise runtime gfx detection now wins over the generic unknown-SKU fallback.

## Verification
- `python -m unittest tests.installer.test_gpu`
- `python -m py_compile auplc_installer/gpu.py tests/installer/test_gpu.py`
- `python -m unittest discover tests/installer`
- LSP diagnostics clean for changed files