### PR TITLE
fix(admin): respect date range for hourly sessions

### DIFF
--- a/runtime/hub/core/stats_handlers.py
+++ b/runtime/hub/core/stats_handlers.py
@@ -447,18 +447,38 @@ class StatsHourlyHandler(APIHandler):
         except ValueError:
             tz_offset = 0
 
+        start_date = self.get_argument("start_date", None)
+        end_date = self.get_argument("end_date", None)
+
         loop = __import__("asyncio").get_event_loop()
-        result = await loop.run_in_executor(None, self._query, days, tz_offset)
+        result = await loop.run_in_executor(None, self._query, days, tz_offset, start_date, end_date)
         self.set_header("Content-Type", "application/json")
         self.finish(json.dumps(result))
 
-    def _query(self, days: int, tz_offset: int):
+    @staticmethod
+    def _date_bounds(days: int, tz_offset: int, start_date: str | None, end_date: str | None):
+        if start_date and end_date:
+            try:
+                start = datetime.strptime(start_date, "%Y-%m-%d") - timedelta(minutes=tz_offset)
+                end = datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1) - timedelta(minutes=tz_offset)
+                if start < end:
+                    return start, end
+            except ValueError:
+                pass
+
+        return datetime.now() - timedelta(days=days), None
+
+    def _query(self, days: int, tz_offset: int, start_date: str | None = None, end_date: str | None = None):
         import sqlalchemy as sa
 
-        since = datetime.now() - timedelta(days=days)
+        since, until = self._date_bounds(days, tz_offset, start_date, end_date)
         offset_sign = "+" if tz_offset >= 0 else "-"
         offset_abs = abs(tz_offset)
         offset_expr = f"datetime(start_time, '{offset_sign}{offset_abs} minutes')"
+        end_clause = "AND start_time < :until " if until is not None else ""
+        params = {"since": since}
+        if until is not None:
+            params["until"] = until
 
         with session_scope() as session:
             rows = session.execute(
@@ -469,9 +489,10 @@ class StatsHourlyHandler(APIHandler):
                     "FROM quota_usage_sessions "
                     "WHERE status IN ('completed', 'cleaned_up') "
                     "AND start_time >= :since "
+                    f"{end_clause}"
                     "GROUP BY hour ORDER BY hour ASC"
                 ),
-                {"since": since},
+                params,
             ).fetchall()
 
         by_hour = {int(r[0]): {"sessions": int(r[1]), "minutes": int(r[2])} for r in rows}

--- a/runtime/hub/frontend/apps/admin/src/pages/Dashboard.tsx
+++ b/runtime/hub/frontend/apps/admin/src/pages/Dashboard.tsx
@@ -136,7 +136,7 @@ export function Dashboard() {
         getDashboardOverview(),
         getUsageTimeSeries(days, granularity),
         getDistribution(days),
-        getHourlyDistribution(days),
+        getHourlyDistribution(days, startDate, endDate),
       ]);
       setOverview(ov);
       setDailyUsage(usage.daily_usage);
@@ -148,7 +148,7 @@ export function Dashboard() {
     } finally {
       setLoading(false);
     }
-  }, [days]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [days, startDate, endDate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load only time series when granularity changes (skip on initial mount, loadAll handles it)
   const isFirstRender = useRef(true);

--- a/runtime/hub/frontend/packages/shared/src/api/stats.ts
+++ b/runtime/hub/frontend/packages/shared/src/api/stats.ts
@@ -4,6 +4,7 @@
 import { apiRequest, adminApiRequest } from "./client.js";
 import type {
   DashboardOverview,
+  HourlyUsage,
   StatsDistributionResponse,
   StatsUsageResponse,
   UserDetail,
@@ -21,9 +22,17 @@ export async function getDistribution(days = 30): Promise<StatsDistributionRespo
   return adminApiRequest<StatsDistributionResponse>(`/stats/distribution?days=${days}`);
 }
 
-export async function getHourlyDistribution(days = 30): Promise<{ hourly: import('../types/stats.js').HourlyUsage[] }> {
+export async function getHourlyDistribution(days = 30, startDate?: string, endDate?: string): Promise<{ hourly: HourlyUsage[] }> {
   const tzOffset = -new Date().getTimezoneOffset(); // minutes ahead of UTC
-  return adminApiRequest(`/stats/hourly?days=${days}&tz_offset=${tzOffset}`);
+  const params = new URLSearchParams({
+    days: String(days),
+    tz_offset: String(tzOffset),
+  });
+  if (startDate && endDate) {
+    params.set("start_date", startDate);
+    params.set("end_date", endDate);
+  }
+  return adminApiRequest(`/stats/hourly?${params.toString()}`);
 }
 
 export async function getUserDetail(username: string, days = 30, granularity: "day" | "week" = "day"): Promise<UserDetail> {


### PR DESCRIPTION
## Jira
AUPPM-74

## Summary
- pass the dashboard's selected start/end dates to the hourly session distribution API
- apply exact local-day bounds before grouping sessions by hour
- keep the existing days-based fallback for older callers

## Verification
- lsp_diagnostics on modified Python and TypeScript files
- python -m py_compile runtime/hub/core/stats_handlers.py
- pnpm --filter @auplc/shared run typecheck
- pnpm --filter @auplc/admin run build