### PR TITLE
fix(spawn): prevent theme toggle form submit

### DIFF
--- a/runtime/hub/frontend/apps/spawn/src/App.tsx
+++ b/runtime/hub/frontend/apps/spawn/src/App.tsx
@@ -346,7 +346,7 @@ function App() {
           <a href={homeUrl}>Home</a>
           <span>/</span>
           <span>Launch Server</span>
-          <button className="spawn-theme-toggle" onClick={toggleTheme} title={theme === 'light' ? 'Dark mode' : 'Light mode'}>
+          <button type="button" className="spawn-theme-toggle" onClick={toggleTheme} title={theme === 'light' ? 'Dark mode' : 'Light mode'}>
             {theme === 'light' ? '🌙' : '☀️'}
           </button>
         </div>


### PR DESCRIPTION
## Summary
- Make the spawn page theme toggle an explicit non-submit button.
- Prevent the theme toggle from submitting the spawn form or becoming the form's implicit Enter-key submit control.

## Root Cause
The spawn React app is rendered inside `#spawn_form`. The spawn page theme toggle was a `<button>` without an explicit `type`, so the browser treated it as `type="submit"`. Because it appears before the launch button in the form, clicking it could submit the form and pressing Enter could activate the theme toggle instead of the intended launch control.

## Implementation Notes
- Add `type="button"` to the spawn page theme toggle.
- Leave the Launch Server button as the intentional `type="submit"` control.
- Scope the fix to the spawn React page; no global top-bar theme logic was changed.

## Verification
- `pnpm run build:spawn`
- LSP diagnostics clean for `runtime/hub/frontend/apps/spawn/src/App.tsx`