### PR TITLE
fix(home): filter resources by current user

### DIFF
--- a/runtime/hub/core/groups.py
+++ b/runtime/hub/core/groups.py
@@ -196,6 +196,27 @@ def get_resources_for_user(
     return list(dict.fromkeys(available_resources))
 
 
+def resolve_resources_for_user(
+    user: JupyterHubUser,
+    team_resource_mapping: dict[str, list[str]],
+    auth_mode: str,
+) -> list[str]:
+    """Resolve the resources visible to a user for UI and spawn flows."""
+    username = user.name.strip()
+
+    if auth_mode in ["auto-login", "dummy"]:
+        return team_resource_mapping.get("official", [])
+
+    available_resources = get_resources_for_user(user, team_resource_mapping)
+    if available_resources:
+        return available_resources
+
+    if not username.startswith("github:"):
+        return team_resource_mapping.get("native-users", team_resource_mapping.get("official", []))
+
+    return ["none"]
+
+
 def is_readonly_group(group: ORMGroup) -> bool:
     """Check if a group's membership is fully read-only.
 

--- a/runtime/hub/core/groups.py
+++ b/runtime/hub/core/groups.py
@@ -200,12 +200,13 @@ def resolve_resources_for_user(
     user: JupyterHubUser,
     team_resource_mapping: dict[str, list[str]],
     auth_mode: str,
+    all_resources: list[str],
 ) -> list[str]:
     """Resolve the resources visible to a user for UI and spawn flows."""
     username = user.name.strip()
 
     if auth_mode in ["auto-login", "dummy"]:
-        return team_resource_mapping.get("official", [])
+        return all_resources
 
     available_resources = get_resources_for_user(user, team_resource_mapping)
     if available_resources:

--- a/runtime/hub/core/handlers.py
+++ b/runtime/hub/core/handlers.py
@@ -71,6 +71,7 @@ _handler_config: dict[str, Any] = {
     "minimum_quota_to_start": 10,
     "default_quota": 0,
     "team_resource_mapping": {},
+    "auth_mode": "auto-login",
 }
 
 
@@ -118,6 +119,7 @@ def configure_handlers(
     default_quota: int = 0,
     team_resource_mapping: dict[str, list[str]] | None = None,
     github_org: str = "",
+    auth_mode: str = "auto-login",
 ) -> None:
     """Configure handler module with runtime settings."""
     if accelerator_options is not None:
@@ -130,6 +132,7 @@ def configure_handlers(
     if team_resource_mapping is not None:
         _handler_config["team_resource_mapping"] = team_resource_mapping
     _handler_config["github_org"] = github_org
+    _handler_config["auth_mode"] = auth_mode
 
 
 # =============================================================================
@@ -905,22 +908,24 @@ class UserQuotaInfoHandler(APIHandler):
 
 
 class ResourcesAPIHandler(APIHandler):
-    """API endpoint for available resources with metadata."""
+    """API endpoint for current user's available resources with metadata."""
 
     @web.authenticated
     async def get(self):
-        """Get all available resources with metadata.
-
-        Note: Access control is handled by the spawner via window.AVAILABLE_RESOURCES
-        injected into the template. This API returns all configured resources.
-        """
+        """Get resources visible to the current user with metadata."""
         from core.config import HubConfig
+        from core.groups import resolve_resources_for_user
 
+        assert self.current_user is not None
         config = HubConfig.get()
 
-        # Return all configured resources - access control is done client-side
-        # based on spawner-injected window.AVAILABLE_RESOURCES
-        available_resources = set(config.resources.images.keys())
+        available_resources = set(
+            resolve_resources_for_user(
+                self.current_user,
+                _handler_config.get("team_resource_mapping", {}),
+                _handler_config.get("auth_mode", "auto-login"),
+            )
+        )
 
         # Build response
         resources_list = []

--- a/runtime/hub/core/handlers.py
+++ b/runtime/hub/core/handlers.py
@@ -924,6 +924,7 @@ class ResourcesAPIHandler(APIHandler):
                 self.current_user,
                 _handler_config.get("team_resource_mapping", {}),
                 _handler_config.get("auth_mode", "auto-login"),
+                list(config.resources.images.keys()),
             )
         )
 

--- a/runtime/hub/core/setup.py
+++ b/runtime/hub/core/setup.py
@@ -198,6 +198,7 @@ def setup_hub(c: Any) -> None:
         default_quota=config.quota.defaultQuota,
         team_resource_mapping=dict(config.teams.mapping),
         github_org=config.github_org_name,
+        auth_mode=config.auth_mode,
     )
 
     if not hasattr(c.JupyterHub, "extra_handlers") or c.JupyterHub.extra_handlers is None:

--- a/runtime/hub/core/spawner/kubernetes.py
+++ b/runtime/hub/core/spawner/kubernetes.py
@@ -165,7 +165,7 @@ class RemoteLabKubeSpawner(KubeSpawner):
     async def get_user_resources(self) -> list[str]:
         """Get available resources for the user based on their JupyterHub group memberships.
 
-        For auto-login/dummy modes, returns the "official" resource set.
+        For auto-login/dummy modes, returns all configured resources.
         For all other users, resolves resources from JupyterHub groups
         (which are synced from GitHub teams or assigned to native users
         via the auth_state_hook). Falls back to legacy pattern matching
@@ -179,7 +179,12 @@ class RemoteLabKubeSpawner(KubeSpawner):
 
         from core.groups import resolve_resources_for_user
 
-        available_resources = resolve_resources_for_user(self.user, self.team_resource_mapping, self.auth_mode)
+        available_resources = resolve_resources_for_user(
+            self.user,
+            self.team_resource_mapping,
+            self.auth_mode,
+            list(self.resource_images.keys()),
+        )
         self.log.debug(f"User '{username}' resolved resources: {available_resources}")
         return available_resources
 

--- a/runtime/hub/core/spawner/kubernetes.py
+++ b/runtime/hub/core/spawner/kubernetes.py
@@ -177,30 +177,11 @@ class RemoteLabKubeSpawner(KubeSpawner):
         username = self.user.name.strip()
         self.log.debug(f"Resolving resources for user: {username}")
 
-        # Auto-login or dummy mode: grant all resources
-        if self.auth_mode in ["auto-login", "dummy"]:
-            self.log.debug(f"Auth mode '{self.auth_mode}': granting all resources")
-            return self.team_resource_mapping.get("official", [])
+        from core.groups import resolve_resources_for_user
 
-        # Resolve resources from JupyterHub groups
-        from core.groups import get_resources_for_user
-
-        available_resources = get_resources_for_user(self.user, self.team_resource_mapping)
-
-        if available_resources:
-            self.log.debug(f"User '{username}' resources from groups: {available_resources}")
-            return available_resources
-
-        # Defensive fallback: auth_state_hook should have already assigned
-        # native users to the "native-users" group, but if that failed for
-        # any reason, fall back to the mapping entry directly.
-        if not username.startswith("github:"):
-            self.log.debug(f"Native user '{username}' has no groups, using default fallback")
-            return self.team_resource_mapping.get("native-users", self.team_resource_mapping.get("official", []))
-
-        # GitHub user with no matching groups
-        self.log.debug(f"No resources found for user '{username}', set to none")
-        return ["none"]
+        available_resources = resolve_resources_for_user(self.user, self.team_resource_mapping, self.auth_mode)
+        self.log.debug(f"User '{username}' resolved resources: {available_resources}")
+        return available_resources
 
     async def options_form(self, _) -> str:
         """Generate the HTML form for resource selection.

--- a/runtime/hub/tests/test_groups.py
+++ b/runtime/hub/tests/test_groups.py
@@ -61,6 +61,7 @@ def load_module(name: str, path: Path):
 
 
 groups = load_module("core.groups", CORE / "groups.py")
+resolve_resources_for_user = groups.resolve_resources_for_user
 sync_user_github_teams = groups.sync_user_github_teams
 
 
@@ -76,8 +77,8 @@ class DummyOrmUser:
 
 
 class DummyUser:
-    def __init__(self, groups):
-        self.name = "github:test"
+    def __init__(self, groups, name="github:test"):
+        self.name = name
         self.orm_user = DummyOrmUser(groups)
 
 
@@ -107,3 +108,44 @@ def test_sync_user_github_teams_skips_removals_when_team_fetch_failed():
     sync_user_github_teams(user, None, {"team-a"}, DummyDb())
 
     assert user.orm_user.groups == [existing_group]
+
+
+def test_resolve_resources_for_user_uses_group_mapping():
+    user = DummyUser([DummyGroup("team-a"), DummyGroup("team-b")])
+
+    resources = resolve_resources_for_user(
+        user,
+        {"team-a": ["cpu", "course-a"], "team-b": ["course-a", "course-b"]},
+        "multi",
+    )
+
+    assert set(resources) == {"cpu", "course-a", "course-b"}
+    assert resources.count("course-a") == 1
+
+
+def test_resolve_resources_for_user_falls_back_for_native_users():
+    user = DummyUser([], name="native-user")
+
+    resources = resolve_resources_for_user(
+        user,
+        {"official": ["cpu"], "native-users": ["code-cpu"]},
+        "multi",
+    )
+
+    assert resources == ["code-cpu"]
+
+
+def test_resolve_resources_for_user_denies_unmapped_github_users():
+    user = DummyUser([])
+
+    resources = resolve_resources_for_user(user, {"official": ["cpu"]}, "multi")
+
+    assert resources == ["none"]
+
+
+def test_resolve_resources_for_user_uses_official_resources_for_auto_login():
+    user = DummyUser([], name="demo-user")
+
+    resources = resolve_resources_for_user(user, {"official": ["cpu", "gpu"]}, "auto-login")
+
+    assert resources == ["cpu", "gpu"]

--- a/runtime/hub/tests/test_groups.py
+++ b/runtime/hub/tests/test_groups.py
@@ -117,6 +117,7 @@ def test_resolve_resources_for_user_uses_group_mapping():
         user,
         {"team-a": ["cpu", "course-a"], "team-b": ["course-a", "course-b"]},
         "multi",
+        ["cpu", "gpu", "code-cpu", "course-a", "course-b"],
     )
 
     assert set(resources) == {"cpu", "course-a", "course-b"}
@@ -130,6 +131,7 @@ def test_resolve_resources_for_user_falls_back_for_native_users():
         user,
         {"official": ["cpu"], "native-users": ["code-cpu"]},
         "multi",
+        ["cpu", "gpu", "code-cpu"],
     )
 
     assert resources == ["code-cpu"]
@@ -138,14 +140,14 @@ def test_resolve_resources_for_user_falls_back_for_native_users():
 def test_resolve_resources_for_user_denies_unmapped_github_users():
     user = DummyUser([])
 
-    resources = resolve_resources_for_user(user, {"official": ["cpu"]}, "multi")
+    resources = resolve_resources_for_user(user, {"official": ["cpu"]}, "multi", ["cpu", "gpu"])
 
     assert resources == ["none"]
 
 
-def test_resolve_resources_for_user_uses_official_resources_for_auto_login():
+def test_resolve_resources_for_user_uses_all_resources_for_auto_login():
     user = DummyUser([], name="demo-user")
 
-    resources = resolve_resources_for_user(user, {"official": ["cpu", "gpu"]}, "auto-login")
+    resources = resolve_resources_for_user(user, {"official": ["cpu"]}, "auto-login", ["cpu", "gpu", "code-cpu"])
 
-    assert resources == ["cpu", "gpu"]
+    assert resources == ["cpu", "gpu", "code-cpu"]


### PR DESCRIPTION
## Summary
- share user resource visibility resolution between spawn and API flows
- make /api/resources return only resources visible to the current user
- add focused tests for group/native/GitHub/auto-login resource resolution

## Verification
- pytest runtime/hub/tests/test_groups.py
- python -m py_compile runtime/hub/core/groups.py runtime/hub/core/spawner/kubernetes.py runtime/hub/core/handlers.py runtime/hub/core/setup.py runtime/hub/tests/test_groups.py