### PR TITLE
build(base): bump ROCm baseline to 7.13

### DIFF
--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -3,6 +3,7 @@
     {"name": "gfx110x", "pytorch_whl": "gfx110X-all"},
     {"name": "gfx1150", "pytorch_whl": "gfx1150"},
     {"name": "gfx1151", "pytorch_whl": "gfx1151"},
+    {"name": "gfx1152", "pytorch_whl": "gfx1152"},
     {"name": "gfx120x", "pytorch_whl": "gfx120X-all"}
   ],
   "default_gpu_target": "gfx1151",

--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -1,10 +1,10 @@
 {
   "gpu_targets": [
-    {"name": "gfx110x", "pytorch_whl": "gfx110X-all", "rocm_sdk": "gfx1103"},
+    {"name": "gfx110x", "pytorch_whl": "gfx110X-all", "rocm_sdk": "gfx110x"},
     {"name": "gfx1150", "pytorch_whl": "gfx1150", "rocm_sdk": "gfx1150"},
     {"name": "gfx1151", "pytorch_whl": "gfx1151", "rocm_sdk": "gfx1151"},
     {"name": "gfx1152", "pytorch_whl": "gfx1152", "rocm_sdk": "gfx1152"},
-    {"name": "gfx120x", "pytorch_whl": "gfx120X-all", "rocm_sdk": "gfx1201"}
+    {"name": "gfx120x", "pytorch_whl": "gfx120X-all", "rocm_sdk": "gfx120x"}
   ],
   "default_gpu_target": "gfx1151",
   "courses": ["CV", "DL", "LLM", "PhySim"]

--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -1,10 +1,10 @@
 {
   "gpu_targets": [
-    {"name": "gfx110x", "pytorch_whl": "gfx110X-all"},
-    {"name": "gfx1150", "pytorch_whl": "gfx1150"},
-    {"name": "gfx1151", "pytorch_whl": "gfx1151"},
-    {"name": "gfx1152", "pytorch_whl": "gfx1152"},
-    {"name": "gfx120x", "pytorch_whl": "gfx120X-all"}
+    {"name": "gfx110x", "pytorch_whl": "gfx110X-all", "rocm_sdk": "gfx1103"},
+    {"name": "gfx1150", "pytorch_whl": "gfx1150", "rocm_sdk": "gfx1150"},
+    {"name": "gfx1151", "pytorch_whl": "gfx1151", "rocm_sdk": "gfx1151"},
+    {"name": "gfx1152", "pytorch_whl": "gfx1152", "rocm_sdk": "gfx1152"},
+    {"name": "gfx120x", "pytorch_whl": "gfx120X-all", "rocm_sdk": "gfx1201"}
   ],
   "default_gpu_target": "gfx1151",
   "courses": ["CV", "DL", "LLM", "PhySim"]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -67,6 +67,7 @@ on:
           - gfx110x
           - gfx1150
           - gfx1151
+          - gfx1152
           - gfx120x
 
 # Build matrix is defined in .github/build-config.json
@@ -489,9 +490,9 @@ jobs:
   # ──────────────────────────────────────────────
   # Base GPU Image (multi-target via GPU_TARGET)
   #
-  # No GPU hardware required — only downloads ROCm tarball + pip wheels.
+  # No GPU hardware required — only installs ROCm apt packages + pip wheels.
   # Uses free-disk-space action to reclaim runner disk for the large image.
-  # Builds 5 GPU targets in parallel via matrix strategy.
+  # Builds GPU targets in parallel via matrix strategy.
   # ──────────────────────────────────────────────
   build-base-gpu:
     name: "Build Base GPU Image (${{ matrix.gpu_target }})"
@@ -622,7 +623,7 @@ jobs:
   # BASE_IMAGE build-arg overrides the default so course images
   # can track the latest GPU base image version from CI.
   #
-  # Each course is built for all 5 GPU targets (course × gpu_target matrix).
+  # Each course is built for every configured GPU target (course × gpu_target matrix).
   # ──────────────────────────────────────────────
   build-courses:
     name: "Build Course: ${{ matrix.course }} (${{ matrix.gpu_target }})"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -538,9 +538,11 @@ jobs:
         id: suffix
         run: |
           echo "tag_suffix=${{ matrix.gpu_target }}" >> "$GITHUB_OUTPUT"
-          # Look up pytorch_whl from gpu-map; fall back to gpu_target if not found
+          # Look up target-specific build metadata; fall back to gpu_target if not found
           WHL=$(echo '${{ needs.changes.outputs.gpu-map }}' | jq -r --arg t "${{ matrix.gpu_target }}" '.[] | select(.name == $t) | .pytorch_whl // .name')
+          SDK=$(echo '${{ needs.changes.outputs.gpu-map }}' | jq -r --arg t "${{ matrix.gpu_target }}" '.[] | select(.name == $t) | .rocm_sdk // .name')
           echo "pytorch_whl=${WHL}" >> "$GITHUB_OUTPUT"
+          echo "rocm_sdk=${SDK}" >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata (target-suffixed tags)
         id: meta-suffixed
@@ -603,6 +605,7 @@ jobs:
           labels: ${{ steps.meta-suffixed.outputs.labels }}
           build-args: |
             GPU_TARGET=${{ matrix.gpu_target }}
+            ROCM_SDK_TARGET=${{ steps.suffix.outputs.rocm_sdk }}
             PYTORCH_WHL_TARGET=${{ steps.suffix.outputs.pytorch_whl }}
           cache-from: type=gha,scope=base-gpu-${{ matrix.gpu_target }}
           cache-to: type=gha,mode=max,scope=base-gpu-${{ matrix.gpu_target }}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The simplest way to deploy AUP Learning Cloud on a single machine in a developme
 - **Hardware**: AMD Ryzen™ AI Halo Device (e.g., AI Max+ 395, AI Max 390)
 - **Memory**: 32GB+ RAM (64GB recommended)
 - **Storage**: 500GB+ SSD
-- **OS**: Ubuntu 24.04.3 LTS
+- **OS**: Ubuntu 24.04.4 LTS
 - **Docker**: Install Docker and configure for non-root access
 
 ```bash
@@ -56,7 +56,7 @@ newgrp docker
 sudo apt install build-essential
 ```
 
-> **Kernel note**: The OEM kernel package follows AMD ROCm's Ryzen APU installation guidance for Ubuntu 24.04. See the [ROCm installation guide for Ryzen APUs](https://rocm.docs.amd.com/en/7.12.0/install/rocm.html?fam=ryzen&gpu=max-pro-395&os=ubuntu&os-version=24.04&i=pkgman) for details.
+> **Kernel note**: The OEM kernel package follows AMD ROCm's Ryzen APU installation guidance for Ubuntu 24.04. See the [ROCm 7.13.0 preview installation guide for Ryzen APUs](https://rocm.docs.amd.com/en/7.13.0-preview/install/rocm.html?fam=ryzen&w=compute&os=ubuntu&ubuntu-ver=24.04&i=pkgman&gpu=max-pro-395&gfx=gfx1151) for details.
 >
 > **Docker note**: See [Docker Post-installation Steps](https://docs.docker.com/engine/install/linux-postinstall/) and [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/) for details.
 

--- a/deploy/ansible/playbooks/pb-rocm.yml
+++ b/deploy/ansible/playbooks/pb-rocm.yml
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-- name: Install ROCm 7.1.0
+- name: Install AMD GPU driver for ROCm 7.13.0
   hosts: all
   become: yes
   roles:

--- a/deploy/ansible/roles/rocm/tasks/main.yml
+++ b/deploy/ansible/roles/rocm/tasks/main.yml
@@ -38,20 +38,20 @@
 
 - name: Download AMDGPU installer
   get_url:
-    url: https://repo.radeon.com/amdgpu-install/7.1/ubuntu/noble/amdgpu-install_7.1.70100-1_all.deb
-    dest: /tmp/amdgpu-install_7.1.70100-1_all.deb
+    url: https://repo.radeon.com/amdgpu-install/31.30/ubuntu/noble/amdgpu-install_31.30.313000-1_all.deb
+    dest: /tmp/amdgpu-install_31.30.313000-1_all.deb
 
 - name: Install AMDGPU installer
   apt:
-    deb: /tmp/amdgpu-install_7.1.70100-1_all.deb
+    deb: /tmp/amdgpu-install_31.30.313000-1_all.deb
 
 - name: Update apt cache again
   apt:
     update_cache: yes
 
-- name: Install ROCm
+- name: Install AMD GPU DKMS driver
   apt:
-    name: rocm
+    name: amdgpu-dkms
     state: present
 
 - name: Ensure render group exists with consistent GID

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -37,7 +37,7 @@ ARG NB_GID=100
 #   gfx1152       RDNA 3.5 — Ryzen AI 300-series iGPU
 #   gfx120x       RDNA 4   — Radeon 9x series (dGPU)
 #
-# ROCm 7.13 ships TheRock Core SDK packages in the multi-arch apt repo.
+# ROCm 7.13 ships TheRock Core SDK packages in the Ubuntu apt repo.
 # GPU_TARGET selects the image tag and PyTorch wheel bucket; ROCM_SDK_TARGET
 # selects the concrete apt SDK package for size-conscious installs.
 ARG GPU_TARGET=gfx1151
@@ -94,7 +94,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     gpg --dearmor -o /etc/apt/keyrings/amdrocm.gpg
 
 # Add AMD ROCm apt repository (Ubuntu 24.04)
-RUN echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404 stable main' \
+RUN echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages/ubuntu2404 stable main' \
     > /etc/apt/sources.list.d/rocm.list
 
 # Install ROCm from apt.

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -28,18 +28,21 @@ ARG NB_USER=jovyan
 ARG NB_UID=1000
 ARG NB_GID=100
 
-# GPU target and ROCm version — override at build time
+# GPU target and ROCm baseline
 #
 # Supported GPU_TARGET values:
 #   gfx110x       RDNA 3   — gfx1100/1101/1102/1103 (dGPU)
 #   gfx1150       RDNA 3.5 — Radeon 890M (Strix Point iGPU)
 #   gfx1151       RDNA 3.5 — Radeon 8060S (Strix Halo iGPU)
+#   gfx1152       RDNA 3.5 — Ryzen AI 300-series iGPU
 #   gfx120x       RDNA 4   — Radeon 9x series (dGPU)
 #
-# The tarball and wheel URLs are derived from GPU_TARGET automatically.
-# Use ROCM_TARBALL_URL / PYTORCH_INDEX_URL to override for edge cases.
+# ROCm 7.13 ships TheRock Core SDK packages in the multi-arch apt repo. The
+# SDK is installed from the all-target meta package so the Dockerfile stays a
+# straight-line course-image baseline while GPU_TARGET selects the matching
+# PyTorch wheel bucket and image tag.
 ARG GPU_TARGET=gfx1151
-ARG ROCM_VERSION=7.12.0
+ARG ROCM_VERSION=7.13.0
 ARG PYTORCH_VERSION=2.9.1
 ARG TORCHVISION_VERSION=0.24.0
 ARG TORCHAUDIO_VERSION=2.9.0
@@ -91,15 +94,15 @@ RUN mkdir -p /etc/apt/keyrings && \
     gpg --dearmor -o /etc/apt/keyrings/amdrocm.gpg
 
 # Add AMD ROCm apt repository (Ubuntu 24.04)
-RUN echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages/ubuntu2404 stable main' \
+RUN echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404 stable main' \
     > /etc/apt/sources.list.d/rocm.list
 
-# Install ROCm from apt (package name uses GPU_TARGET, e.g. amdrocm7.12-gfx110X-all)
+# Install ROCm from apt.
 # After install, create standard /opt/rocm/{bin,lib,include} symlinks — the amdrocm
 # packages install into /opt/rocm/core-<ver>/ without the standard top-level layout,
 # so hipcc and device bitcode are not found via PATH / LD_LIBRARY_PATH otherwise.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends amdrocm${ROCM_VERSION%.*}-${GPU_TARGET} && \
+    apt-get install -y --no-install-recommends amdrocm-core-sdk${ROCM_VERSION%.*} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     CORE_BASE=$(ls -d /opt/rocm/core-[0-9]*.[0-9]* 2>/dev/null | sort -V | tail -1) && \
@@ -112,10 +115,10 @@ RUN apt-get update && \
 
 # Install ROCm PyTorch.
 #
-# The apt and pip repos do NOT use the same naming convention for the generic
-# RDNA buckets: apt ships `amdrocm<ver>-gfx110x` / `amdrocm<ver>-gfx120x`, but
-# the pip wheel index at https://repo.amd.com/rocm/whl/ only serves the
-# `gfx110X-all` / `gfx120X-all` paths (the short lowercase paths return 403).
+# The SDK apt package covers all ROCm 7.13 targets. The pip wheel index at
+# https://repo.amd.com/rocm/whl/ still uses the "long" `gfx110X-all` /
+# `gfx120X-all` paths for generic RDNA buckets (the short lowercase paths
+# return 403), so image targets still map to wheel targets below.
 #
 # CI passes PYTORCH_WHL_TARGET explicitly via .github/build-config.json. For
 # local builds driven by dockerfiles/Makefile or auplc-installer — which only

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -108,8 +108,9 @@ RUN apt-get update && \
     CORE_BASE=$(ls -d /opt/rocm/core-[0-9]*.[0-9]* 2>/dev/null | sort -V | tail -1) && \
     if [ -n "$CORE_BASE" ]; then \
         for d in bin lib include libexec share; do \
-            [ ! -e /opt/rocm/$d ] && [ -e "$CORE_BASE/$d" ] && \
+            if [ ! -e /opt/rocm/$d ] && [ -e "$CORE_BASE/$d" ]; then \
                 ln -s "$CORE_BASE/$d" /opt/rocm/$d; \
+            fi; \
         done; \
     fi
 

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -37,11 +37,11 @@ ARG NB_GID=100
 #   gfx1152       RDNA 3.5 — Ryzen AI 300-series iGPU
 #   gfx120x       RDNA 4   — Radeon 9x series (dGPU)
 #
-# ROCm 7.13 ships TheRock Core SDK packages in the multi-arch apt repo. The
-# SDK is installed from the all-target meta package so the Dockerfile stays a
-# straight-line course-image baseline while GPU_TARGET selects the matching
-# PyTorch wheel bucket and image tag.
+# ROCm 7.13 ships TheRock Core SDK packages in the multi-arch apt repo.
+# GPU_TARGET selects the image tag and PyTorch wheel bucket; ROCM_SDK_TARGET
+# selects the concrete apt SDK package for size-conscious installs.
 ARG GPU_TARGET=gfx1151
+ARG ROCM_SDK_TARGET=gfx1151
 ARG ROCM_VERSION=7.13.0
 ARG PYTORCH_VERSION=2.9.1
 ARG TORCHVISION_VERSION=0.24.0
@@ -102,7 +102,7 @@ RUN echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.
 # packages install into /opt/rocm/core-<ver>/ without the standard top-level layout,
 # so hipcc and device bitcode are not found via PATH / LD_LIBRARY_PATH otherwise.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends amdrocm-core-sdk${ROCM_VERSION%.*} && \
+    apt-get install -y --no-install-recommends amdrocm-core-sdk${ROCM_VERSION%.*}-${ROCM_SDK_TARGET} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     CORE_BASE=$(ls -d /opt/rocm/core-[0-9]*.[0-9]* 2>/dev/null | sort -V | tail -1) && \
@@ -115,10 +115,11 @@ RUN apt-get update && \
 
 # Install ROCm PyTorch.
 #
-# The SDK apt package covers all ROCm 7.13 targets. The pip wheel index at
-# https://repo.amd.com/rocm/whl/ still uses the "long" `gfx110X-all` /
-# `gfx120X-all` paths for generic RDNA buckets (the short lowercase paths
-# return 403), so image targets still map to wheel targets below.
+# The SDK apt packages use concrete gfx targets such as `gfx1103` and
+# `gfx1201`. The pip wheel index at https://repo.amd.com/rocm/whl/ still uses
+# the "long" `gfx110X-all` / `gfx120X-all` paths for generic RDNA buckets (the
+# short lowercase paths return 403), so image targets still map to wheel
+# targets below.
 #
 # CI passes PYTORCH_WHL_TARGET explicitly via .github/build-config.json. For
 # local builds driven by dockerfiles/Makefile or auplc-installer — which only

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -115,11 +115,11 @@ RUN apt-get update && \
 
 # Install ROCm PyTorch.
 #
-# The SDK apt packages use concrete gfx targets such as `gfx1103` and
-# `gfx1201`. The pip wheel index at https://repo.amd.com/rocm/whl/ still uses
-# the "long" `gfx110X-all` / `gfx120X-all` paths for generic RDNA buckets (the
-# short lowercase paths return 403), so image targets still map to wheel
-# targets below.
+# The SDK apt packages accept the same generic RDNA bucket names as GPU_TARGET,
+# such as `gfx110x` and `gfx120x`. The pip wheel index at
+# https://repo.amd.com/rocm/whl/ uses the "long" `gfx110X-all` /
+# `gfx120X-all` paths for those buckets (the short lowercase paths return 403),
+# so image targets still map to wheel targets below.
 #
 # CI passes PYTORCH_WHL_TARGET explicitly via .github/build-config.json. For
 # local builds driven by dockerfiles/Makefile or auplc-installer — which only

--- a/dockerfiles/Base/README.md
+++ b/dockerfiles/Base/README.md
@@ -24,7 +24,8 @@ SOFTWARE.
 ## GPU Base Image (`Dockerfile.rocm`)
 
 Multi-target ROCm GPU base image. Set `GPU_TARGET` to build for any supported architecture.
-`Dockerfile.rocm` defaults to ROCm 7.12.0 unless `ROCM_VERSION` is overridden at build time.
+`Dockerfile.rocm` tracks the current course-image baseline: ROCm 7.13.0 Core SDK
+from AMD's multi-arch apt repository, plus ROCm-enabled PyTorch wheels.
 
 ### Supported Targets
 
@@ -33,15 +34,19 @@ Multi-target ROCm GPU base image. Set `GPU_TARGET` to build for any supported ar
 | gfx110x       | RDNA 3   | gfx1100/1101/1102/1103 (dGPU)   | gfx110X-all              |
 | gfx1150       | RDNA 3.5 | Strix (Radeon 890M)             | gfx1150                  |
 | gfx1151       | RDNA 3.5 | Strix Halo (Radeon 8060S)       | gfx1151                  |
-| gfx1152       | RDNA 3.5 |                                 | gfx1152                  |
+| gfx1152       | RDNA 3.5 | Ryzen AI 300-series iGPU        | gfx1152                  |
 | gfx120x       | RDNA 4   | gfx1201 (dGPU: RX 9070 XT, R9700, RX 9600 GRE, …) | gfx120X-all |
 
-The `GPU_TARGET` value is the short name used by the AMD apt repo
-(`amdrocm7.12-<GPU_TARGET>`) and as the image-tag suffix. The pip wheel index
-at <https://repo.amd.com/rocm/whl/> uses the "long" `gfxNNNX-all` path for
-the generic RDNA 3 / RDNA 4 buckets; `Dockerfile.rocm` maps short → long
-automatically. CI passes `PYTORCH_WHL_TARGET` explicitly (see
-`.github/build-config.json`).
+The ROCm SDK is installed from the all-target `amdrocm-core-sdk7.13` apt meta
+package. The `GPU_TARGET` value selects the PyTorch wheel bucket and becomes
+the image-tag suffix. The pip wheel index at <https://repo.amd.com/rocm/whl/>
+uses the "long" `gfxNNNX-all` path for the generic RDNA 3 / RDNA 4 buckets;
+`Dockerfile.rocm` maps short → long automatically. CI passes
+`PYTORCH_WHL_TARGET` explicitly (see `.github/build-config.json`).
+
+The baseline PyTorch stack follows AMD's ROCm 7.13.0 wheel set while keeping
+the existing course-facing framework versions: `torch==2.9.1+rocm7.13.0`,
+`torchvision==0.24.0+rocm7.13.0`, and `torchaudio==2.9.0+rocm7.13.0`.
 
 ### Build
 
@@ -57,15 +62,15 @@ docker build --build-arg GPU_TARGET=gfx120x \
 make base-rocm                         # default target
 make base-rocm GPU_TARGET=gfx120x      # RDNA 4 desktop GPUs
 make base-rocm GPU_TARGET=gfx110x      # RDNA 3 desktop GPUs
+make base-rocm GPU_TARGET=gfx1152      # Ryzen AI 300-series iGPU
 ```
 
-### Override URLs
+### Override PyTorch Wheel URL
 
-For edge cases, override the derived URLs directly:
+For edge cases, override the derived PyTorch wheel URL directly:
 
 ```bash
 docker build \
-  --build-arg ROCM_TARBALL_URL=https://custom.url/rocm.tar.gz \
   --build-arg PYTORCH_INDEX_URL=https://custom.url/whl/ \
   --file Dockerfile.rocm .
 ```

--- a/dockerfiles/Base/README.md
+++ b/dockerfiles/Base/README.md
@@ -25,7 +25,7 @@ SOFTWARE.
 
 Multi-target ROCm GPU base image. Set `GPU_TARGET` to build for any supported architecture.
 `Dockerfile.rocm` tracks the current course-image baseline: ROCm 7.13.0 Core SDK
-from AMD's multi-arch apt repository, plus ROCm-enabled PyTorch wheels.
+from AMD's Ubuntu 24.04 apt repository, plus ROCm-enabled PyTorch wheels.
 
 ### Supported Targets
 

--- a/dockerfiles/Base/README.md
+++ b/dockerfiles/Base/README.md
@@ -40,8 +40,8 @@ from AMD's multi-arch apt repository, plus ROCm-enabled PyTorch wheels.
 The `GPU_TARGET` value selects the PyTorch wheel bucket and becomes the
 image-tag suffix. The ROCm SDK is installed from the matching arch-specific
 `amdrocm-core-sdk7.13-<ROCM_SDK_TARGET>` apt package to avoid pulling every
-supported architecture into each image. Generic image buckets use a concrete
-SDK target: `gfx110x` installs `gfx1103`, and `gfx120x` installs `gfx1201`.
+supported architecture into each image. Generic image buckets use the matching
+generic SDK target, for example `gfx110x` and `gfx120x`.
 
 The pip wheel index at <https://repo.amd.com/rocm/whl/> uses the "long"
 `gfxNNNX-all` path for the generic RDNA 3 / RDNA 4 buckets; `Dockerfile.rocm`

--- a/dockerfiles/Base/README.md
+++ b/dockerfiles/Base/README.md
@@ -37,12 +37,16 @@ from AMD's multi-arch apt repository, plus ROCm-enabled PyTorch wheels.
 | gfx1152       | RDNA 3.5 | Ryzen AI 300-series iGPU        | gfx1152                  |
 | gfx120x       | RDNA 4   | gfx1201 (dGPU: RX 9070 XT, R9700, RX 9600 GRE, …) | gfx120X-all |
 
-The ROCm SDK is installed from the all-target `amdrocm-core-sdk7.13` apt meta
-package. The `GPU_TARGET` value selects the PyTorch wheel bucket and becomes
-the image-tag suffix. The pip wheel index at <https://repo.amd.com/rocm/whl/>
-uses the "long" `gfxNNNX-all` path for the generic RDNA 3 / RDNA 4 buckets;
-`Dockerfile.rocm` maps short → long automatically. CI passes
-`PYTORCH_WHL_TARGET` explicitly (see `.github/build-config.json`).
+The `GPU_TARGET` value selects the PyTorch wheel bucket and becomes the
+image-tag suffix. The ROCm SDK is installed from the matching arch-specific
+`amdrocm-core-sdk7.13-<ROCM_SDK_TARGET>` apt package to avoid pulling every
+supported architecture into each image. Generic image buckets use a concrete
+SDK target: `gfx110x` installs `gfx1103`, and `gfx120x` installs `gfx1201`.
+
+The pip wheel index at <https://repo.amd.com/rocm/whl/> uses the "long"
+`gfxNNNX-all` path for the generic RDNA 3 / RDNA 4 buckets; `Dockerfile.rocm`
+maps short → long automatically. CI passes `PYTORCH_WHL_TARGET` and
+`ROCM_SDK_TARGET` explicitly (see `.github/build-config.json`).
 
 The baseline PyTorch stack follows AMD's ROCm 7.13.0 wheel set while keeping
 the existing course-facing framework versions: `torch==2.9.1+rocm7.13.0`,
@@ -56,6 +60,7 @@ docker build -t ghcr.io/amdresearch/auplc-base:latest --file Dockerfile.rocm .
 
 # Specific target
 docker build --build-arg GPU_TARGET=gfx120x \
+  --build-arg ROCM_SDK_TARGET=gfx1201 \
   -t ghcr.io/amdresearch/auplc-base:latest-gfx120x --file Dockerfile.rocm .
 
 # Using make (from dockerfiles/ directory)

--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -17,7 +17,7 @@ MIRROR_PIP ?=
 MIRROR_NPM ?=
 
 # GPU target architecture (short AMD apt-repo name; e.g. gfx110x, gfx1150,
-# gfx1151, gfx120x). Dockerfile.rocm maps this to the corresponding pip
+# gfx1151, gfx1152, gfx120x). Dockerfile.rocm maps this to the corresponding pip
 # wheel path (gfx110X-all / gfx120X-all for the RDNA 3 / RDNA 4 buckets).
 GPU_TARGET ?= gfx1151
 

--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -21,14 +21,7 @@ MIRROR_NPM ?=
 # wheel path (gfx110X-all / gfx120X-all for the RDNA 3 / RDNA 4 buckets).
 GPU_TARGET ?= gfx1151
 
-ifeq ($(GPU_TARGET),gfx110x)
-DEFAULT_ROCM_SDK_TARGET := gfx1103
-else ifeq ($(GPU_TARGET),gfx120x)
-DEFAULT_ROCM_SDK_TARGET := gfx1201
-else
-DEFAULT_ROCM_SDK_TARGET := $(GPU_TARGET)
-endif
-ROCM_SDK_TARGET ?= $(DEFAULT_ROCM_SDK_TARGET)
+ROCM_SDK_TARGET ?= $(GPU_TARGET)
 
 # GPU base image used by course Dockerfiles (override to track a specific version)
 GPU_BASE_IMAGE ?= ghcr.io/amdresearch/auplc-base:latest

--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -21,6 +21,15 @@ MIRROR_NPM ?=
 # wheel path (gfx110X-all / gfx120X-all for the RDNA 3 / RDNA 4 buckets).
 GPU_TARGET ?= gfx1151
 
+ifeq ($(GPU_TARGET),gfx110x)
+DEFAULT_ROCM_SDK_TARGET := gfx1103
+else ifeq ($(GPU_TARGET),gfx120x)
+DEFAULT_ROCM_SDK_TARGET := gfx1201
+else
+DEFAULT_ROCM_SDK_TARGET := $(GPU_TARGET)
+endif
+ROCM_SDK_TARGET ?= $(DEFAULT_ROCM_SDK_TARGET)
+
 # GPU base image used by course Dockerfiles (override to track a specific version)
 GPU_BASE_IMAGE ?= ghcr.io/amdresearch/auplc-base:latest
 CODE_GPU_BASE_IMAGE ?= ghcr.io/amdresearch/auplc-base:latest-$(GPU_TARGET)
@@ -63,6 +72,7 @@ base-rocm:
 
 	cd Base && docker build $(BUILD_ARGS) \
 		--build-arg GPU_TARGET=$(GPU_TARGET) \
+		--build-arg ROCM_SDK_TARGET=$(ROCM_SDK_TARGET) \
 		$(if $(MIRROR_PREFIX),--build-arg BASE_IMAGE=$(MIRROR_PREFIX)/docker.io/library/ubuntu:24.04,) \
 		-t ghcr.io/amdresearch/auplc-base:latest --file Dockerfile.rocm .
 	docker tag ghcr.io/amdresearch/auplc-base:latest ghcr.io/amdresearch/auplc-base:latest-$(GPU_TARGET)


### PR DESCRIPTION
## Summary
- Bump the ROCm GPU base image baseline to ROCm 7.13.0 and the matching ROCm-enabled PyTorch wheel set.
- Add the `gfx1152` build target and keep generic `gfx110x` / `gfx120x` image targets supported.
- Split ROCm SDK target selection from PyTorch wheel bucket selection so apt packages and wheel indexes can use their own target names.
- Refresh ROCm host setup docs and ansible installer references for the ROCm 7.13 flow.

## Implementation Notes
- ROCm is installed from AMD's Ubuntu 24.04 apt repository using target-specific `amdrocm-core-sdk7.13-<target>` packages.
- Generic CI targets use `gfx110x` / `gfx120x` for the ROCm SDK packages and `gfx110X-all` / `gfx120X-all` for PyTorch wheel buckets.
- The `/opt/rocm` symlink fallback is idempotent so it does not fail when the 7.13 packages already create those links through `update-alternatives`.
- Local Makefile builds default `ROCM_SDK_TARGET` to `GPU_TARGET` while CI passes explicit values from `.github/build-config.json`.

## Validation
- `jq empty .github/build-config.json`
- YAML parse for `.github/workflows/docker-build.yml`
- `python3 -m unittest tests.installer.test_gpu tests.installer.test_overlay`
- Local Docker build for `gfx110x` with `ROCM_SDK_TARGET=gfx110x` and `PYTORCH_WHL_TARGET=gfx110X-all`
- Local image smoke test: `/opt/rocm/bin/hipcc` exists and `torch.__version__` is `2.9.1+rocm7.13.0`
- GitHub Actions `Build Docker Images` workflow dispatch run `26497377590` succeeded for `base-gpu` / `all`
