### PR TITLE
Align auplc-installer CLI with TUI and add install dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ sudo apt install python3-questionary   # optional; improves the TUI prompts
 ```bash
 git clone https://github.com/AMDResearch/aup-learning-cloud.git
 cd aup-learning-cloud
-./auplc-installer install --image-tag=develop
+./auplc-installer install
 ```
 
-The installer runs as your user and prompts for sudo once when root access is needed. By default it **pulls** pre-built images from the configured registry (`ghcr.io/amdresearch` unless overridden).
+The installer runs as your user and prompts for sudo once when root access is needed. By default it **pulls** pre-built images from GitHub Container Registry (`ghcr.io/amdresearch` unless overridden): it auto-detects your AMD GPU model, then pulls the matching GPU-specific image tags (for example `develop-gfx1150` on Strix Point).
 
 A successful install looks like this:
 
@@ -94,27 +94,19 @@ This operation needs root privileges. Requesting sudo password...
   ✓ [7/8] Refreshing values overlay from node labels  (0.2s)
   ✓ [8/8] Deploying JupyterHub runtime (helm install + wait)  (9.2s)
 
+
+   _    _   _ ____    _                          _                  ____ _                 _
+  / \  | | | |  _ \  | |    ___  __ _ _ __ _ __ (_)_ __   __ _     / ___| | ___  _   _  __| |
+ / _ \ | | | | |_) | | |   / _ \/ _` | '__| '_ \| | '_ \ / _` |   | |   | |/ _ \| | | |/ _` |
+/ ___ \| |_| |  __/  | |__|  __/ (_| | |  | | | | | | | | (_| |   | |___| | (_) | |_| | (_| |
+/_/   \_\___/|_|     |_____\___|\__,_|_|  |_| |_|_|_| |_|\__, |    \____|_|\___/ \__,_|\__,_|
+                                                         |___/
     You have successfully installed AUP Learning Cloud!
 
     Open in your browser: http://localhost:30890
     (auto-logged-in as 'student' — no login needed)
 
     kubectl is configured at $HOME/.kube/config; try `kubectl get nodes`
-```
-
-Preview the plan without installing:
-
-```bash
-./auplc-installer install --dry-run --image-tag=develop
-```
-
-Common options:
-
-```bash
-./auplc-installer install --gpu=strix-halo              # override GPU detection
-./auplc-installer install --image-source=build        # build images locally instead of pull
-./auplc-installer install --runtime=containerd          # portable/offline-oriented K3s runtime
-./auplc-installer install --mirror=mirror.example.com # registry mirror
 ```
 
 See the full guide at [Quick Start](https://amdresearch.github.io/aup-learning-cloud/installation/quick-start.html) and [Single-Node Deployment](https://amdresearch.github.io/aup-learning-cloud/installation/single-node.html).

--- a/README.md
+++ b/README.md
@@ -33,14 +33,15 @@ AUP Learning Cloud is a tailored JupyterHub deployment designed to provide an in
 The simplest way to deploy AUP Learning Cloud on a single machine in a development or demo environment.
 
 ### Prerequisites
-- **Hardware**: AMD Ryzen™ AI Halo Device (e.g., AI Max+ 395, AI Max 390)
+- **Hardware**: Supported **Ryzen AI 300 series and above** APUs and **Radeon 9000 series** PCIe GPUs.
 - **Memory**: 32GB+ RAM (64GB recommended)
 - **Storage**: 500GB+ SSD
 - **OS**: Ubuntu 24.04.3 LTS
 - **Docker**: Install Docker and configure for non-root access
+- **TUI deps**: `python3-questionary` and `python3-prompt-toolkit` (apt) for the recommended interactive installer; conda/venv users use `pip install questionary prompt_toolkit`
 
 ```bash
-# Install the OEM kernel for AMD Ryzen-series APU ROCm support (reboot required)
+# Ryzen AI APU only: OEM kernel for ROCm on Ubuntu 24.04 (reboot required)
 sudo apt update && sudo apt install linux-image-6.14.0-1018-oem
 
 # Install Docker
@@ -54,11 +55,16 @@ newgrp docker
 
 # Install Build Tools
 sudo apt install build-essential
+
+# TUI dependencies (required for the recommended interactive install)
+sudo apt install python3-questionary python3-prompt-toolkit
 ```
 
-> **Kernel note**: The OEM kernel package follows AMD ROCm's Ryzen APU installation guidance for Ubuntu 24.04. See the [ROCm installation guide for Ryzen APUs](https://rocm.docs.amd.com/en/7.12.0/install/rocm.html?fam=ryzen&gpu=max-pro-395&os=ubuntu&os-version=24.04&i=pkgman) for details.
+> **Kernel note** (Ryzen AI APU only): The OEM kernel package follows AMD ROCm's Ryzen APU installation guidance for Ubuntu 24.04. See the [ROCm installation guide for Ryzen APUs](https://rocm.docs.amd.com/en/7.12.0/install/rocm.html?fam=ryzen&gpu=max-pro-395&os=ubuntu&os-version=24.04&i=pkgman) for details. Radeon dGPU systems typically use the stock Ubuntu kernel—check ROCm docs for your GPU.
 >
 > **Docker note**: See [Docker Post-installation Steps](https://docs.docker.com/engine/install/linux-postinstall/) and [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/) for details.
+>
+> **TUI note**: **System Python (apt):** install `python3-questionary` and `python3-prompt-toolkit` as shown above. **Conda or virtualenv users:** use `pip install questionary prompt_toolkit` inside your active environment instead of the apt packages. These are required for the interactive TUI; non-interactive `./auplc-installer install` does not need them.
 
 ### Installation
 
@@ -67,7 +73,6 @@ sudo apt install build-essential
 ```bash
 git clone https://github.com/AMDResearch/aup-learning-cloud.git
 cd aup-learning-cloud
-sudo apt install python3-questionary   # optional; improves the TUI prompts
 ./auplc-installer                      # pick Install, accept defaults, set Image tag to develop
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ sudo apt install python3-questionary   # optional; improves the TUI prompts
 ```bash
 git clone https://github.com/AMDResearch/aup-learning-cloud.git
 cd aup-learning-cloud
-./auplc-installer install
+./auplc-installer install --image-tag=develop
 ```
 
-The installer runs as your user and prompts for sudo once when root access is needed. By default it **pulls** pre-built images from GitHub Container Registry (`ghcr.io/amdresearch` unless overridden): it auto-detects your AMD GPU model, then pulls the matching GPU-specific image tags (for example `develop-gfx1150` on Strix Point).
+The installer runs as your user and prompts for sudo once when root access is needed. By default it **pulls** pre-built images from GitHub Container Registry (`ghcr.io/amdresearch` unless you override `--image-registry`). It **auto-detects your AMD GPU** (via `rocminfo` or KFD topology), then pulls the **GPU-matched image tags** for that hardware—for example `auplc-base:develop-gfx1150` on Strix Point, or `auplc-cv:develop-gfx1151` on Strix Halo.
 
 A successful install looks like this:
 
@@ -94,19 +94,27 @@ This operation needs root privileges. Requesting sudo password...
   ✓ [7/8] Refreshing values overlay from node labels  (0.2s)
   ✓ [8/8] Deploying JupyterHub runtime (helm install + wait)  (9.2s)
 
-
-   _    _   _ ____    _                          _                  ____ _                 _
-  / \  | | | |  _ \  | |    ___  __ _ _ __ _ __ (_)_ __   __ _     / ___| | ___  _   _  __| |
- / _ \ | | | | |_) | | |   / _ \/ _` | '__| '_ \| | '_ \ / _` |   | |   | |/ _ \| | | |/ _` |
-/ ___ \| |_| |  __/  | |__|  __/ (_| | |  | | | | | | | | (_| |   | |___| | (_) | |_| | (_| |
-/_/   \_\___/|_|     |_____\___|\__,_|_|  |_| |_|_|_| |_|\__, |    \____|_|\___/ \__,_|\__,_|
-                                                         |___/
     You have successfully installed AUP Learning Cloud!
 
     Open in your browser: http://localhost:30890
     (auto-logged-in as 'student' — no login needed)
 
     kubectl is configured at $HOME/.kube/config; try `kubectl get nodes`
+```
+
+Preview the plan without installing:
+
+```bash
+./auplc-installer install --dry-run --image-tag=develop
+```
+
+Common options:
+
+```bash
+./auplc-installer install --gpu=strix-halo              # override GPU detection
+./auplc-installer install --image-source=build          # build images locally instead of pull
+./auplc-installer install --runtime=containerd          # portable/offline-oriented K3s runtime
+./auplc-installer install --mirror=mirror.example.com   # registry mirror
 ```
 
 See the full guide at [Quick Start](https://amdresearch.github.io/aup-learning-cloud/installation/quick-start.html) and [Single-Node Deployment](https://amdresearch.github.io/aup-learning-cloud/installation/single-node.html).

--- a/README.md
+++ b/README.md
@@ -76,10 +76,8 @@ sudo apt install python3-questionary   # optional; improves the TUI prompts
 ```bash
 git clone https://github.com/AMDResearch/aup-learning-cloud.git
 cd aup-learning-cloud
-./auplc-installer install --image-tag=develop
+./auplc-installer install
 ```
-
-The installer runs as your user and prompts for sudo once when root access is needed. By default it **pulls** pre-built images from GitHub Container Registry (`ghcr.io/amdresearch` unless you override `--image-registry`). It **auto-detects your AMD GPU** (via `rocminfo` or KFD topology), then pulls the **GPU-matched image tags** for that hardware—for example `auplc-base:develop-gfx1150` on Strix Point, or `auplc-cv:develop-gfx1151` on Strix Halo.
 
 A successful install looks like this:
 
@@ -94,27 +92,18 @@ This operation needs root privileges. Requesting sudo password...
   ✓ [7/8] Refreshing values overlay from node labels  (0.2s)
   ✓ [8/8] Deploying JupyterHub runtime (helm install + wait)  (9.2s)
 
+   _    _   _ ____    _                          _                  ____ _                 _
+  / \  | | | |  _ \  | |    ___  __ _ _ __ _ __ (_)_ __   __ _     / ___| | ___  _   _  __| |
+ / _ \ | | | | |_) | | |   / _ \/ _` | '__| '_ \| | '_ \ / _` |   | |   | |/ _ \| | | |/ _` |
+/ ___ \| |_| |  __/  | |__|  __/ (_| | |  | | | | | | | | (_| |   | |___| | (_) | |_| | (_| |
+/_/   \_\___/|_|     |_____\___|\__,_|_|  |_| |_|_|_| |_|\__, |    \____|_|\___/ \__,_|\__,_|
+                                                         |___/
     You have successfully installed AUP Learning Cloud!
 
     Open in your browser: http://localhost:30890
     (auto-logged-in as 'student' — no login needed)
 
     kubectl is configured at $HOME/.kube/config; try `kubectl get nodes`
-```
-
-Preview the plan without installing:
-
-```bash
-./auplc-installer install --dry-run --image-tag=develop
-```
-
-Common options:
-
-```bash
-./auplc-installer install --gpu=strix-halo              # override GPU detection
-./auplc-installer install --image-source=build          # build images locally instead of pull
-./auplc-installer install --runtime=containerd          # portable/offline-oriented K3s runtime
-./auplc-installer install --mirror=mirror.example.com   # registry mirror
 ```
 
 See the full guide at [Quick Start](https://amdresearch.github.io/aup-learning-cloud/installation/quick-start.html) and [Single-Node Deployment](https://amdresearch.github.io/aup-learning-cloud/installation/single-node.html).
@@ -188,12 +177,10 @@ Current environments are configured via `custom.resources.images` in `runtime/va
 
 The `auplc-default`, `auplc-base`, and `Course-*` images remain notebook and course focused. Browser-based coding is provided by generic code-server images instead of per-course VS Code image variants. Resources launch code-server when their `custom.resources.metadata.<resource>.launchMode` is set to `code-server`; the default configuration uses `code-cpu` for CPU-only coding workspaces and `code-gpu` for GPU-accelerated coding workspaces.
 
-Build the generic coding images from the repository root with:
+Build the images:
 
 ```bash
-make -C dockerfiles code-cpu
-make -C dockerfiles code-gpu GPU_TARGET=gfx1151
-make -C dockerfiles code
+./auplc-installer img build base-rocm --gpu=strix
 ```
 
 The code-server container starts on port `8888` with `code-server --auth none`. This is safe only when the user pod is reachable exclusively through JupyterHub and the JupyterHub proxy authentication boundary. Do not expose the code-server pod port directly through a NodePort, LoadBalancer, ingress, or other unauthenticated route.

--- a/README.md
+++ b/README.md
@@ -61,25 +61,68 @@ sudo apt install build-essential
 > **Docker note**: See [Docker Post-installation Steps](https://docs.docker.com/engine/install/linux-postinstall/) and [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/) for details.
 
 ### Installation
+
+**Interactive (recommended):**
+
 ```bash
 git clone https://github.com/AMDResearch/aup-learning-cloud.git
 cd aup-learning-cloud
-sudo ./auplc-installer install
+sudo apt install python3-questionary   # optional; improves the TUI prompts
+./auplc-installer                      # pick Install, accept defaults, set Image tag to develop
 ```
-After installation completes, open http://localhost:30890 in your browser. No login credentials are required - you will be automatically logged in.
+
+**Non-interactive:**
+
+```bash
+git clone https://github.com/AMDResearch/aup-learning-cloud.git
+cd aup-learning-cloud
+./auplc-installer install --image-tag=develop
+```
+
+The installer runs as your user and prompts for sudo once when root access is needed. By default it **pulls** pre-built images from the configured registry (`ghcr.io/amdresearch` unless overridden).
+
+A successful install looks like this:
+
+```text
+This operation needs root privileges. Requesting sudo password...
+  ✓ [1/8] Detecting GPU  (0.2s)
+  ✓ [2/8] Generating values overlay (initial)  (0.0s)
+  ✓ [3/8] Installing helm + k9s  (0.0s)
+  ✓ [4/8] Installing K3s (single-node)  (3.8s)
+  ✓ [5/8] Pulling custom + external images  (25.0s)
+  ✓ [6/8] Deploying ROCm GPU device plugin + node labeller  (0.2s)
+  ✓ [7/8] Refreshing values overlay from node labels  (0.2s)
+  ✓ [8/8] Deploying JupyterHub runtime (helm install + wait)  (9.2s)
+
+    You have successfully installed AUP Learning Cloud!
+
+    Open in your browser: http://localhost:30890
+    (auto-logged-in as 'student' — no login needed)
+
+    kubectl is configured at $HOME/.kube/config; try `kubectl get nodes`
+```
+
+Preview the plan without installing:
+
+```bash
+./auplc-installer install --dry-run --image-tag=develop
+```
 
 Common options:
+
 ```bash
-sudo ./auplc-installer install --gpu=strix-halo   # specify GPU type
-sudo ./auplc-installer install --docker=0          # use containerd instead of Docker
-sudo ./auplc-installer install --mirror=mirror.example.com  # use registry mirror
+./auplc-installer install --gpu=strix-halo              # override GPU detection
+./auplc-installer install --image-source=build        # build images locally instead of pull
+./auplc-installer install --runtime=containerd          # portable/offline-oriented K3s runtime
+./auplc-installer install --mirror=mirror.example.com # registry mirror
 ```
 
-See more at [link](https://amdresearch.github.io/aup-learning-cloud/installation/single-node.html#runtime-and-mirror-configuration)
+See the full guide at [Quick Start](https://amdresearch.github.io/aup-learning-cloud/installation/quick-start.html) and [Single-Node Deployment](https://amdresearch.github.io/aup-learning-cloud/installation/single-node.html).
 
 ### Uninstall
+
 ```bash
-sudo ./auplc-installer uninstall
+./auplc-installer uninstall
 ```
 
 ## Cluster Installation

--- a/auplc_installer/cli.py
+++ b/auplc_installer/cli.py
@@ -40,6 +40,7 @@ from auplc_installer.pack import pack_bundle
 from auplc_installer.progress import stage
 from auplc_installer.rocm import deploy_rocm_gpu_device_plugin
 from auplc_installer.state import InstallerState
+from auplc_installer.summary import format_configuration_summary, resolve_install_image_source
 from auplc_installer.util import (
     InstallerError,
     ensure_sudo_session,
@@ -73,12 +74,16 @@ Commands:
                         optional `questionary` package is not installed.
 
   install [--pull]      Full installation (k3s + images + runtime)
-                        Default: build images locally via Makefile
-                        --pull: use pre-built images from GHCR (no local build needed)
+                        Default: pull pre-built images from --image-registry
+                        --pull: legacy alias for --image-source=pull
+                        --image-source=build: build via dockerfiles/Makefile
+
+  install --dry-run     Show Configuration summary without making changes
+                        (also accepts --try-run). No sudo required.
 
   pack [--local]        Create offline deployment bundle (requires Docker + internet)
-                        Default: pull pre-built images from GHCR
-                        --local: build images locally then pack (needs build deps)
+                        Default: pull pre-built images from registry
+                        --local: legacy alias for building locally before pack
 
   uninstall             Remove everything (K3s + runtime)
   install-tools         Install helm and k9s
@@ -101,6 +106,7 @@ Commands:
 
 Options (can also be set via environment variables):
   --gpu=TYPE        Override auto-detected GPU type. Accepts:
+                      auto       - auto-detect (same as omitting the flag)
                       phx        - Phoenix Point iGPU (gfx1100..gfx1103)
                       strix      - Strix Point iGPU (gfx1150)
                       strix-halo - Strix Halo iGPU (gfx1151)
@@ -112,10 +118,28 @@ Options (can also be set via environment variables):
                     Auto-detection uses rocminfo or KFD topology.
                     Env: GPU_TYPE
 
+  --runtime=MODE    K3s container runtime: docker (default) or containerd.
+                    Env: K3S_USE_DOCKER (1 = docker, 0 = containerd)
+                    Legacy: --docker=0|1 (still supported; --runtime wins)
+
+  --image-source=SRC  Custom image acquisition for install:
+                      pull  - fetch pre-built images from --image-registry
+                      build - build from dockerfiles/ via Makefile
+                    Default: pull. Legacy: ghcr is an alias for pull;
+                    install --pull is an alias for --image-source=pull
+
+  --image-registry=PREFIX
+                    Registry prefix for custom images (default: ghcr.io/amdresearch)
+                    Env: IMAGE_REGISTRY
+
+  --image-tag=TAG   Custom-image tag prefix (default: latest). GPU suffix
+                    appended automatically. Env: IMAGE_TAG
+
   --docker=0|1      Use host Docker as K3s container runtime (default: 1).
                     1 = Docker mode: images visible to K3s immediately.
                     0 = containerd mode: images exported for offline use.
                     Env: K3S_USE_DOCKER
+                    Prefer --runtime=docker|containerd for new scripts.
 
   --courses=SPEC    Restrict the install/pack to a subset of courses. Affects
                     image build/pull AND the rendered values.local.yaml so
@@ -130,6 +154,10 @@ Options (can also be set via environment variables):
   -y, --yes         Assume yes to all prompts (for scripted/CI use).
                     Env: AUPLC_YES=1
 
+  --dry-run, --try-run
+                    With ``install``: print Configuration summary and exit.
+                    Does not prompt for sudo or change the system.
+
   -v, --verbose     Stream every subprocess line live (default is a quiet
                     "progress-bar" mode where only stage labels show, and
                     captured output is dumped only when a command fails).
@@ -142,22 +170,24 @@ Options (can also be set via environment variables):
 
   Examples:
     ./auplc-installer tui                              # interactive wizard
+    ./auplc-installer install --dry-run                # preview defaults
+    ./auplc-installer install --image-source=pull --image-tag=develop
+    ./auplc-installer install --runtime=containerd --image-source=build
     ./auplc-installer install --gpu=strix-halo
-    ./auplc-installer install --gpu=phx --docker=0
+    ./auplc-installer install --gpu=auto --dry-run
+    ./auplc-installer install --gpu=phx --docker=0     # legacy flags
     ./auplc-installer install --courses=basic          # cpu + gpu only
     ./auplc-installer install --courses=cpu,gpu,Course-CV
     ./auplc-installer img build base-rocm --gpu=strix
     ./auplc-installer install --mirror=mirror.example.com
 
-Image Registry:
-  IMAGE_REGISTRY  Registry prefix for custom images (default: ghcr.io/amdresearch)
-                  Override when pulling from a fork or private registry.
-  IMAGE_TAG       Image tag prefix (default: latest). GPU suffix appended automatically.
-                  Use "develop" for images built from the develop branch.
+Image Registry (legacy env-only aliases still work):
+  IMAGE_REGISTRY  Same as --image-registry (default: ghcr.io/amdresearch)
+  IMAGE_TAG       Same as --image-tag (default: latest)
 
 Offline Deployment:
   1. On a machine with internet access, create bundle:
-       ./auplc-installer pack --gpu=strix-halo          # pull from GHCR
+       ./auplc-installer pack --gpu=strix-halo          # pull from registry
        ./auplc-installer pack --gpu=strix-halo --local   # or build locally
 
   2. Transfer bundle to air-gapped machine, then:
@@ -186,12 +216,17 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     # Global flags
     p.add_argument("--gpu", dest="gpu_type", default=None)
+    p.add_argument("--runtime", dest="runtime", default=None)
     p.add_argument("--docker", dest="use_docker", default=None)
+    p.add_argument("--image-source", dest="image_source", default=None)
+    p.add_argument("--image-registry", dest="image_registry", default=None)
+    p.add_argument("--image-tag", dest="image_tag", default=None)
     p.add_argument("--mirror", dest="mirror_prefix", default=None)
     p.add_argument("--mirror-pip", dest="mirror_pip", default=None)
     p.add_argument("--mirror-npm", dest="mirror_npm", default=None)
     p.add_argument("--courses", dest="courses", default=None)
     p.add_argument("-y", "--yes", dest="assume_yes", action="store_true")
+    p.add_argument("--dry-run", "--try-run", dest="dry_run", action="store_true")
     p.add_argument(
         "-v",
         "--verbose",
@@ -208,9 +243,23 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _apply_global_flags(state: InstallerState, args: argparse.Namespace) -> None:
     if args.gpu_type is not None:
-        state.gpu_type = args.gpu_type
-    if args.use_docker is not None:
+        state.gpu_type = "" if args.gpu_type.lower() == "auto" else args.gpu_type
+    if args.runtime is not None:
+        runtime = args.runtime.lower()
+        if runtime == "docker":
+            state.use_docker = True
+        elif runtime == "containerd":
+            state.use_docker = False
+        else:
+            raise InstallerError(f"Unknown --runtime={args.runtime!r} (expected docker or containerd)")
+    elif args.use_docker is not None:
         state.use_docker = args.use_docker not in ("0", "false", "False")
+    if args.image_source is not None:
+        state.image_source = args.image_source
+    if args.image_registry is not None:
+        state.image_registry = args.image_registry
+    if args.image_tag is not None:
+        state.image_tag = args.image_tag
     if args.mirror_prefix is not None:
         state.mirror_prefix = args.mirror_prefix
     if args.mirror_pip is not None:
@@ -225,6 +274,25 @@ def _apply_global_flags(state: InstallerState, args: argparse.Namespace) -> None
         state.verbose = True
     # Propagate verbose flag to util.run_streaming.
     set_verbose(state.verbose)
+
+
+def _install_pull_and_label(
+    state: InstallerState,
+    *,
+    legacy_pull: bool,
+) -> tuple[bool, str]:
+    return resolve_install_image_source(
+        image_source=state.image_source,
+        legacy_pull=legacy_pull,
+        offline_mode=state.offline_mode,
+        bundle_dir=state.bundle_dir,
+    )
+
+
+def cmd_install_plan(state: InstallerState, *, legacy_pull: bool = False) -> None:
+    """Print the install Configuration summary without side effects."""
+    _, label = _install_pull_and_label(state, legacy_pull=legacy_pull)
+    sys.stdout.write(format_configuration_summary(state, image_source_label=label) + "\n")
 
 
 # ---------------------------------------------------------------------------
@@ -253,7 +321,7 @@ def cmd_install(state: InstallerState, *, pull: bool) -> None:
 def _cmd_install_inner(state: InstallerState, *, pull: bool) -> None:
     """Body of ``cmd_install`` after sudo session has been primed."""
     # Pre-compute the image-stage label so the user knows up-front which path
-    # the installer is taking (offline / GHCR pull / local build).
+    # the installer is taking (offline / pull / build).
     if state.offline_mode:
         image_stage_label = "Loading images from offline bundle"
     elif pull:
@@ -667,12 +735,16 @@ def main(argv: Sequence[str] | None = None) -> None:
     for tok in argv:
         if (
             tok.startswith("--gpu=")
+            or tok.startswith("--runtime=")
             or tok.startswith("--docker=")
+            or tok.startswith("--image-source=")
+            or tok.startswith("--image-registry=")
+            or tok.startswith("--image-tag=")
             or tok.startswith("--mirror=")
             or tok.startswith("--mirror-pip=")
             or tok.startswith("--mirror-npm=")
             or tok.startswith("--courses=")
-            or tok in ("-y", "--yes", "-v", "--verbose", "--version")
+            or tok in ("-y", "--yes", "-v", "--verbose", "--version", "--dry-run", "--try-run")
         ):
             flags.append(tok)
         else:
@@ -684,7 +756,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     try:
         state = InstallerState.from_environment(script_dir=script_dir)
         _apply_global_flags(state, args)
-        _dispatch(args.command, list(args.rest), state, source_root=script_dir)
+        _dispatch(args.command, list(args.rest), state, source_root=script_dir, dry_run=args.dry_run)
     except InstallerError as exc:
         log_error(str(exc))
         sys.exit(1)
@@ -699,6 +771,7 @@ def _dispatch(
     state: InstallerState,
     *,
     source_root: Path,
+    dry_run: bool = False,
 ) -> None:
     # Default behaviour when invoked with no subcommand: launch the TUI in
     # an interactive terminal, fall back to printing help in a piped /
@@ -720,9 +793,19 @@ def _dispatch(
         return
 
     if cmd == "install":
-        pull = bool(rest) and rest[0] == "--pull"
+        legacy_pull = "--pull" in rest
+        rest = [t for t in rest if t != "--pull"]
+        if rest:
+            raise InstallerError(f"Unexpected install argument(s): {' '.join(rest)}")
+        if dry_run:
+            cmd_install_plan(state, legacy_pull=legacy_pull)
+            return
+        pull, _ = _install_pull_and_label(state, legacy_pull=legacy_pull)
         cmd_install(state, pull=pull)
         return
+
+    if dry_run:
+        raise InstallerError("--dry-run is only supported with the install command")
 
     if cmd == "pack":
         local_build = bool(rest) and rest[0] == "--local"

--- a/auplc_installer/cli.py
+++ b/auplc_installer/cli.py
@@ -723,6 +723,13 @@ def _resolve_source_root() -> Path:
 
 def main(argv: Sequence[str] | None = None) -> None:
     argv = list(argv) if argv is not None else sys.argv[1:]
+
+    # Custom help text (add_help=False on the parser). Intercept -h/--help
+    # before argparse runs so `./auplc-installer --help` works as users expect.
+    if any(tok in ("-h", "--help") for tok in argv):
+        show_help()
+        return
+
     parser = _build_parser()
 
     # Argparse refuses positional + --foo=bar interleaving in some edge

--- a/auplc_installer/images.py
+++ b/auplc_installer/images.py
@@ -172,7 +172,7 @@ def pull_custom_images(
 
     tag = f"{image_tag}-{cfg.gpu_target}"
     log_section(
-        "Pulling pre-built custom images from GHCR...\n"
+        "Pulling pre-built custom images from registry...\n"
         f"  GPU_TARGET={cfg.gpu_target}, tag={tag}\n"
         f"  Courses: {courses.description()}"
     )

--- a/auplc_installer/pack.py
+++ b/auplc_installer/pack.py
@@ -443,7 +443,7 @@ def pack_bundle(
 
     log("===========================================")
     log("AUP Learning Cloud - Pack Offline Bundle")
-    log("  Image source: " + ("local build" if local_build else "pull from GHCR"))
+    log("  Image source: " + ("build" if local_build else "pull"))
     log("===========================================")
 
     require_command("docker", install_hint="Docker is required for pack.")

--- a/auplc_installer/state.py
+++ b/auplc_installer/state.py
@@ -45,6 +45,10 @@ class InstallerState:
     image_registry: str = DEFAULT_IMAGE_REGISTRY
     image_tag: str = DEFAULT_IMAGE_TAG
 
+    # Install image acquisition override (CLI --image-source=pull|build).
+    # None => default ``pull`` (matches TUI); legacy ``install --pull`` also selects pull.
+    image_source: str | None = None
+
     # Course selection (drives image filtering + teams.mapping override)
     courses: CourseSelection = field(default_factory=CourseSelection.default)
 

--- a/auplc_installer/summary.py
+++ b/auplc_installer/summary.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Portions of this file consist of AI-generated content.
+
+"""Configuration summary formatting shared by the TUI and CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from auplc_installer.colors import bold, bold_cyan, bright_cyan, dim, green
+from auplc_installer.state import InstallerState
+from auplc_installer.util import InstallerError
+
+# Canonical image-source labels shown in Configuration summary (TUI + CLI).
+IMAGE_SOURCE_PULL = "pull"
+IMAGE_SOURCE_BUILD = "build"
+
+
+def normalize_image_source(value: str) -> str:
+    """Map CLI/TUI input to a canonical ``pull`` or ``build`` label."""
+    src = value.lower()
+    if src in ("ghcr", "pull"):
+        return IMAGE_SOURCE_PULL
+    if src == "build":
+        return IMAGE_SOURCE_BUILD
+    raise InstallerError(f"Unknown --image-source={value!r} (expected pull or build)")
+
+
+def resolve_install_image_source(
+    *,
+    image_source: str | None,
+    legacy_pull: bool = False,
+    offline_mode: bool = False,
+    bundle_dir: Path | None = None,
+) -> tuple[bool, str]:
+    """Return ``(pull, label)`` for an install plan.
+
+    ``pull=True`` means fetch custom images from the configured registry.
+    ``pull=False`` means build custom images locally via Makefile.
+
+    Precedence: offline bundle > explicit ``--image-source`` > legacy
+    ``install --pull`` > default ``pull`` (matches the TUI default).
+    """
+    if offline_mode:
+        location = bundle_dir or "."
+        return False, f"Offline bundle ({location})"
+
+    if image_source is not None:
+        label = normalize_image_source(image_source)
+        return label == IMAGE_SOURCE_PULL, label
+
+    if legacy_pull:
+        return True, IMAGE_SOURCE_PULL
+
+    return True, IMAGE_SOURCE_PULL
+
+
+def format_configuration_summary(state: InstallerState, *, image_source_label: str = "") -> str:
+    """Human-readable install plan (plain text; TUI adds colours separately)."""
+    runtime = "Docker" if state.use_docker else "containerd"
+    gpu = state.gpu_type or "auto-detect"
+
+    lines = ["Configuration summary", f"  GPU              : {gpu}", f"  K3s runtime      : {runtime}"]
+    if image_source_label:
+        lines.append(f"  Image source     : {image_source_label}")
+    lines.append(f"  Image registry   : {state.image_registry}")
+    lines.append(f"  Image tag        : {state.image_tag}")
+    lines.append(f"  Registry mirror  : {state.mirror_prefix or '(none)'}")
+    lines.append(f"  PyPI mirror      : {state.mirror_pip or '(default)'}")
+    lines.append(f"  npm mirror       : {state.mirror_npm or '(default)'}")
+    lines.append(f"  Courses          : {state.courses.description()}")
+    return "\n".join(lines)
+
+
+def format_configuration_summary_colored(state: InstallerState, *, image_source_label: str = "") -> str:
+    """TUI-friendly coloured variant of :func:`format_configuration_summary`."""
+    runtime = "Docker" if state.use_docker else "containerd"
+
+    def row(key: str, value: str, *, accent: bool = False, faint: bool = False) -> str:
+        if faint:
+            v = dim(value)
+        elif accent:
+            v = bold(value)
+        else:
+            v = green(value)
+        return f"  {bright_cyan(key.ljust(17))}: {v}"
+
+    lines = [bold_cyan("Configuration summary")]
+    lines.append(row("GPU", state.gpu_type or "auto-detect"))
+    lines.append(row("K3s runtime", runtime))
+    if image_source_label:
+        lines.append(row("Image source", image_source_label, accent=True))
+    lines.append(row("Image registry", state.image_registry))
+    lines.append(row("Image tag", state.image_tag))
+    if state.mirror_prefix:
+        lines.append(row("Registry mirror", state.mirror_prefix))
+    else:
+        lines.append(row("Registry mirror", "(none)", faint=True))
+    if state.mirror_pip:
+        lines.append(row("PyPI mirror", state.mirror_pip))
+    else:
+        lines.append(row("PyPI mirror", "(default)", faint=True))
+    if state.mirror_npm:
+        lines.append(row("npm mirror", state.mirror_npm))
+    else:
+        lines.append(row("npm mirror", "(default)", faint=True))
+    lines.append(row("Courses", state.courses.description(), accent=True))
+    return "\n".join(lines)

--- a/auplc_installer/tui.py
+++ b/auplc_installer/tui.py
@@ -39,6 +39,7 @@ from auplc_installer.colors import (
     yellow,
 )
 from auplc_installer.state import InstallerState
+from auplc_installer.summary import format_configuration_summary_colored
 from auplc_installer.util import (
     InstallerError,
     log,
@@ -612,41 +613,6 @@ def _flow_select_courses(state: InstallerState) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _summary(state: InstallerState, *, image_source_label: str = "") -> str:
-    runtime = "Docker" if state.use_docker else "containerd"
-
-    def row(key: str, value: str, *, accent: bool = False, faint: bool = False) -> str:
-        if faint:
-            v = dim(value)
-        elif accent:
-            v = bold(value)
-        else:
-            v = green(value)
-        return f"  {bright_cyan(key.ljust(17))}: {v}"
-
-    lines = [bold_cyan("Configuration summary")]
-    lines.append(row("GPU", state.gpu_type or "auto-detect"))
-    lines.append(row("K3s runtime", runtime))
-    if image_source_label:
-        lines.append(row("Image source", image_source_label, accent=True))
-    lines.append(row("Image registry", state.image_registry))
-    lines.append(row("Image tag", state.image_tag))
-    if state.mirror_prefix:
-        lines.append(row("Registry mirror", state.mirror_prefix))
-    else:
-        lines.append(row("Registry mirror", "(none)", faint=True))
-    if state.mirror_pip:
-        lines.append(row("PyPI mirror", state.mirror_pip))
-    else:
-        lines.append(row("PyPI mirror", "(default)", faint=True))
-    if state.mirror_npm:
-        lines.append(row("npm mirror", state.mirror_npm))
-    else:
-        lines.append(row("npm mirror", "(default)", faint=True))
-    lines.append(row("Courses", state.courses.description(), accent=True))
-    return "\n".join(lines)
-
-
 def _flow_install(state: InstallerState) -> None:
     """Run the full install wizard. Raises ``_CancelledError`` on user-aborts."""
     _flow_select_gpu(state)
@@ -660,21 +626,19 @@ def _flow_install(state: InstallerState) -> None:
         image_source = _ask_select(
             "Image source",
             (
-                Choice("pull", "GHCR pull   - fetch pre-built images (fastest; no build deps)"),
-                Choice("build", "Local build - build from dockerfiles/ via Makefile"),
+                Choice("pull", "pull  - fetch pre-built images from registry (default)"),
+                Choice("build", "build - build from dockerfiles/ via Makefile"),
             ),
             default_value="pull",
         )
-        image_source_label = (
-            "GHCR pull (pre-built images)" if image_source == "pull" else "Local build (dockerfiles/Makefile)"
-        )
+        image_source_label = image_source
         pull = image_source == "pull"
         _flow_collect_image_coords(state)
         _flow_collect_mirrors(state)
 
     _flow_select_courses(state)
 
-    log("\n" + _summary(state, image_source_label=image_source_label) + "\n")
+    log("\n" + format_configuration_summary_colored(state, image_source_label=image_source_label) + "\n")
     if not _ask_confirm("Proceed with installation?", default=True):
         raise _CancelledError
 
@@ -694,8 +658,8 @@ def _flow_pack(state: InstallerState, source_root) -> None:
     pack_mode = _ask_select(
         "Pack image source",
         (
-            Choice("pull", "Pull from GHCR (fast, requires pull access)"),
-            Choice("local", "Build locally (needs build deps; slower)"),
+            Choice("pull", "pull  - pull pre-built images from registry (default)"),
+            Choice("build", "build - build locally then pack (needs build deps)"),
         ),
         default_value="pull",
     )
@@ -703,15 +667,14 @@ def _flow_pack(state: InstallerState, source_root) -> None:
     _flow_collect_mirrors(state)
     _flow_select_courses(state)
 
-    label = "GHCR pull" if pack_mode == "pull" else "Local build"
-    log("\n" + _summary(state, image_source_label=label))
+    log("\n" + format_configuration_summary_colored(state, image_source_label=pack_mode))
     log("\nThis will create an offline bundle archive in the current directory.")
     if not _ask_confirm("Proceed?", default=True):
         raise _CancelledError
 
     from auplc_installer.cli import cmd_pack
 
-    cmd_pack(state, local_build=(pack_mode == "local"), source_root=source_root)
+    cmd_pack(state, local_build=(pack_mode == "build"), source_root=source_root)
 
 
 def _flow_uninstall(state: InstallerState) -> None:

--- a/tests/installer/test_cli_install_options.py
+++ b/tests/installer/test_cli_install_options.py
@@ -21,6 +21,7 @@ from auplc_installer.summary import (
     normalize_image_source,
     resolve_install_image_source,
 )
+from auplc_installer.util import InstallerError
 
 
 class NormalizeImageSourceTests(unittest.TestCase):
@@ -32,7 +33,7 @@ class NormalizeImageSourceTests(unittest.TestCase):
         self.assertEqual(normalize_image_source("build"), IMAGE_SOURCE_BUILD)
 
     def test_unknown_raises(self) -> None:
-        with self.assertRaises(Exception):
+        with self.assertRaises(InstallerError):
             normalize_image_source("nope")
 
 
@@ -78,7 +79,7 @@ class ResolveInstallImageSourceTests(unittest.TestCase):
         self.assertIn("Offline bundle", label)
 
     def test_unknown_source_raises(self) -> None:
-        with self.assertRaises(Exception):
+        with self.assertRaises(InstallerError):
             resolve_install_image_source(image_source="nope", legacy_pull=False)
 
 

--- a/tests/installer/test_cli_install_options.py
+++ b/tests/installer/test_cli_install_options.py
@@ -162,6 +162,14 @@ class InstallDryRunTests(unittest.TestCase):
         out = buf.getvalue()
         self.assertIn("  Image source     : pull", out)
 
+    def test_help_flag_prints_usage(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            main(["--help"])
+        out = buf.getvalue()
+        self.assertIn("Usage: ./auplc-installer", out)
+        self.assertIn("install --dry-run", out)
+
     @patch("auplc_installer.cli._resolve_source_root")
     @patch("auplc_installer.cli.InstallerState.from_environment")
     def test_main_install_dry_run(self, mock_from_env, mock_root) -> None:

--- a/tests/installer/test_cli_install_options.py
+++ b/tests/installer/test_cli_install_options.py
@@ -1,0 +1,189 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Portions of this file consist of AI-generated content.
+
+"""Tests for CLI/TUI parity helpers (summary + install image-source resolution)."""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from auplc_installer.catalog import COURSE_PRESET_ALL, CourseSelection
+from auplc_installer.cli import _apply_global_flags, _build_parser, cmd_install_plan, main
+from auplc_installer.state import InstallerState
+from auplc_installer.summary import (
+    IMAGE_SOURCE_BUILD,
+    IMAGE_SOURCE_PULL,
+    format_configuration_summary,
+    normalize_image_source,
+    resolve_install_image_source,
+)
+
+
+class NormalizeImageSourceTests(unittest.TestCase):
+    def test_pull_and_ghcr_alias(self) -> None:
+        self.assertEqual(normalize_image_source("pull"), IMAGE_SOURCE_PULL)
+        self.assertEqual(normalize_image_source("ghcr"), IMAGE_SOURCE_PULL)
+
+    def test_build(self) -> None:
+        self.assertEqual(normalize_image_source("build"), IMAGE_SOURCE_BUILD)
+
+    def test_unknown_raises(self) -> None:
+        with self.assertRaises(Exception):
+            normalize_image_source("nope")
+
+
+class ResolveInstallImageSourceTests(unittest.TestCase):
+    def test_default_is_pull(self) -> None:
+        pull, label = resolve_install_image_source(image_source=None, legacy_pull=False)
+        self.assertTrue(pull)
+        self.assertEqual(label, IMAGE_SOURCE_PULL)
+
+    def test_legacy_pull_flag(self) -> None:
+        pull, label = resolve_install_image_source(image_source=None, legacy_pull=True)
+        self.assertTrue(pull)
+        self.assertEqual(label, IMAGE_SOURCE_PULL)
+
+    def test_explicit_pull(self) -> None:
+        pull, label = resolve_install_image_source(image_source="pull", legacy_pull=False)
+        self.assertTrue(pull)
+        self.assertEqual(label, IMAGE_SOURCE_PULL)
+
+    def test_explicit_ghcr_alias(self) -> None:
+        pull, label = resolve_install_image_source(image_source="ghcr", legacy_pull=False)
+        self.assertTrue(pull)
+        self.assertEqual(label, IMAGE_SOURCE_PULL)
+
+    def test_explicit_build(self) -> None:
+        pull, label = resolve_install_image_source(image_source="build", legacy_pull=True)
+        self.assertFalse(pull)
+        self.assertEqual(label, IMAGE_SOURCE_BUILD)
+
+    def test_explicit_build_overrides_legacy_pull(self) -> None:
+        pull, label = resolve_install_image_source(image_source="build", legacy_pull=True)
+        self.assertFalse(pull)
+        self.assertEqual(label, IMAGE_SOURCE_BUILD)
+
+    def test_offline_bundle(self) -> None:
+        pull, label = resolve_install_image_source(
+            image_source="pull",
+            legacy_pull=False,
+            offline_mode=True,
+            bundle_dir=Path("/tmp/bundle"),
+        )
+        self.assertFalse(pull)
+        self.assertIn("Offline bundle", label)
+
+    def test_unknown_source_raises(self) -> None:
+        with self.assertRaises(Exception):
+            resolve_install_image_source(image_source="nope", legacy_pull=False)
+
+
+class FormatConfigurationSummaryTests(unittest.TestCase):
+    def test_includes_core_fields(self) -> None:
+        state = InstallerState(
+            gpu_type="strix-halo",
+            use_docker=True,
+            image_registry="ghcr.io/example",
+            image_tag="develop",
+            courses=CourseSelection(picks=list(COURSE_PRESET_ALL)),
+        )
+        text = format_configuration_summary(state, image_source_label=IMAGE_SOURCE_PULL)
+        self.assertIn("Configuration summary", text)
+        self.assertIn("strix-halo", text)
+        self.assertIn("Docker", text)
+        self.assertIn("  Image source     : pull", text)
+        self.assertIn("ghcr.io/example", text)
+        self.assertIn("develop", text)
+        self.assertIn("Course-CV", text)
+
+
+class ApplyGlobalFlagsTests(unittest.TestCase):
+    def test_gpu_auto_clears_override(self) -> None:
+        state = InstallerState(gpu_type="strix")
+        parser = _build_parser()
+        args = parser.parse_args(["--gpu=auto"])
+        _apply_global_flags(state, args)
+        self.assertEqual(state.gpu_type, "")
+
+    def test_runtime_containerd(self) -> None:
+        state = InstallerState(use_docker=True)
+        parser = _build_parser()
+        args = parser.parse_args(["--runtime=containerd"])
+        _apply_global_flags(state, args)
+        self.assertFalse(state.use_docker)
+
+    def test_runtime_wins_over_docker_flag(self) -> None:
+        state = InstallerState(use_docker=True)
+        parser = _build_parser()
+        args = parser.parse_args(["--runtime=containerd", "--docker=1"])
+        _apply_global_flags(state, args)
+        self.assertFalse(state.use_docker)
+
+    def test_image_flags(self) -> None:
+        state = InstallerState()
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "--image-source=pull",
+                "--image-registry=registry.example.com/org",
+                "--image-tag=develop",
+            ]
+        )
+        _apply_global_flags(state, args)
+        self.assertEqual(state.image_source, "pull")
+        self.assertEqual(state.image_registry, "registry.example.com/org")
+        self.assertEqual(state.image_tag, "develop")
+
+
+class InstallDryRunTests(unittest.TestCase):
+    def test_install_dry_run_prints_summary(self) -> None:
+        state = InstallerState(
+            image_source="pull",
+            image_tag="develop",
+            courses=CourseSelection(picks=list(COURSE_PRESET_ALL)),
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cmd_install_plan(state, legacy_pull=False)
+        out = buf.getvalue()
+        self.assertIn("Configuration summary", out)
+        self.assertIn("develop", out)
+        self.assertIn("  Image source     : pull", out)
+
+    def test_install_dry_run_defaults_to_pull(self) -> None:
+        state = InstallerState()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cmd_install_plan(state, legacy_pull=False)
+        out = buf.getvalue()
+        self.assertIn("  Image source     : pull", out)
+
+    @patch("auplc_installer.cli._resolve_source_root")
+    @patch("auplc_installer.cli.InstallerState.from_environment")
+    def test_main_install_dry_run(self, mock_from_env, mock_root) -> None:
+        mock_root.return_value = Path("/repo")
+        mock_from_env.return_value = InstallerState(image_tag="develop")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            main(["install", "--dry-run", "--image-tag=develop"])
+        out = buf.getvalue()
+        self.assertIn("Configuration summary", out)
+        self.assertIn("develop", out)
+        self.assertIn("  Image source     : pull", out)
+
+    @patch("auplc_installer.cli._resolve_source_root")
+    @patch("auplc_installer.cli.InstallerState.from_environment")
+    def test_dry_run_without_install_errors(self, mock_from_env, mock_root) -> None:
+        mock_root.return_value = Path("/repo")
+        mock_from_env.return_value = InstallerState()
+        with self.assertRaises(SystemExit) as ctx:
+            main(["detect-gpu", "--dry-run"])
+        self.assertEqual(ctx.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add TUI-aligned CLI flags: `--runtime`, `--image-source`, `--image-registry`, `--image-tag`, and `--gpu=auto`
- Add `install --dry-run` / `--try-run` to print the Configuration summary without sudo or system changes
- Default install image acquisition to `pull` (matching the TUI) and unify TUI/CLI wording to `pull` / `build` instead of GHCR-specific labels
- Extract shared summary formatting into `auplc_installer/summary.py`; legacy `--pull`, `--docker`, `ghcr`, and env vars remain supported

## Test plan
- [x] `python -m unittest discover tests/installer -v` (103 tests pass)
- [x] `./auplc-installer install --dry-run --image-tag=develop` prints expected Configuration summary with `Image source : pull`
- [ ] `./auplc-installer install --image-source=build --dry-run` shows `Image source : build`
- [ ] Full `./auplc-installer install --image-source=pull --image-tag=develop` on a test host


Made with [Cursor](https://cursor.com)