### PR TITLE
Add code-server support to auplc-installer

### DIFF
--- a/auplc_installer/catalog.py
+++ b/auplc_installer/catalog.py
@@ -45,6 +45,8 @@ class Course:
 COURSE_CATALOG: tuple[Course, ...] = (
     Course("cpu", "auplc-default", False, "base-cpu", "Base CPU (Python Base Environment)"),
     Course("gpu", "auplc-base", True, "base-rocm", "Base GPU (GPU Base Environment)"),
+    Course("code-cpu", "auplc-code-cpu", False, "code-cpu", "Code Server CPU Environment"),
+    Course("code-gpu", "auplc-code-gpu", True, "code-gpu", "Code Server GPU Environment"),
     Course("Course-CV", "auplc-cv", True, "cv", "Computer Vision Course"),
     Course("Course-DL", "auplc-dl", True, "dl", "Deep Learning Course"),
     Course("Course-LLM", "auplc-llm", True, "llm", "Large Language Model Course"),
@@ -54,7 +56,7 @@ COURSE_CATALOG: tuple[Course, ...] = (
 COURSE_KEYS_ALL: tuple[str, ...] = tuple(c.key for c in COURSE_CATALOG)
 COURSE_BY_KEY: dict[str, Course] = {c.key: c for c in COURSE_CATALOG}
 
-COURSE_PRESET_BASIC: tuple[str, ...] = ("cpu", "gpu")
+COURSE_PRESET_BASIC: tuple[str, ...] = ("cpu", "gpu", "code-cpu", "code-gpu")
 COURSE_PRESET_ALL: tuple[str, ...] = COURSE_KEYS_ALL
 
 
@@ -78,12 +80,39 @@ HUB_IMAGE_NAME = "auplc-hub"
 
 
 BASE_TEAM_MAPPING: dict[str, list[str]] = {
-    "cpu": ["cpu"],
-    "gpu": ["Course-CV", "Course-DL", "Course-LLM", "Course-PhySim"],
-    "official": ["cpu", "gpu", "Course-CV", "Course-DL", "Course-LLM", "Course-PhySim"],
+    "cpu": ["cpu", "code-cpu"],
+    "gpu": ["code-gpu", "Course-CV", "Course-DL", "Course-LLM", "Course-PhySim"],
+    "official": [
+        "cpu",
+        "gpu",
+        "code-cpu",
+        "code-gpu",
+        "Course-CV",
+        "Course-DL",
+        "Course-LLM",
+        "Course-PhySim",
+    ],
     "AUP": ["Course-CV", "Course-DL", "Course-LLM", "Course-PhySim"],
-    "native-users": ["Course-CV", "Course-DL", "Course-LLM", "Course-PhySim", "cpu", "gpu"],
-    "github-users": ["cpu", "gpu", "Course-CV", "Course-DL", "Course-LLM", "Course-PhySim"],
+    "native-users": [
+        "code-cpu",
+        "code-gpu",
+        "Course-CV",
+        "Course-DL",
+        "Course-LLM",
+        "Course-PhySim",
+        "cpu",
+        "gpu",
+    ],
+    "github-users": [
+        "cpu",
+        "gpu",
+        "code-cpu",
+        "code-gpu",
+        "Course-CV",
+        "Course-DL",
+        "Course-LLM",
+        "Course-PhySim",
+    ],
 }
 
 

--- a/auplc_installer/cli.py
+++ b/auplc_installer/cli.py
@@ -46,6 +46,7 @@ from auplc_installer.util import (
     ensure_sudo_session,
     log,
     log_error,
+    log_success,
     set_verbose,
     start_sudo_keepalive,
 )
@@ -99,7 +100,7 @@ Commands:
   rt remove             Remove JupyterHub runtime
 
   img build [target...] Build custom images (default: all, or hub + selected courses)
-                        Targets: all, hub, base-cpu, base-rocm, cv, dl, llm, physim
+                        Targets: all, hub, base-cpu, base-rocm, code, code-cpu, code-gpu, cv, dl, llm, physim
   img pull              Pull external images for offline use
 
   detect-gpu            Show detected GPU configuration
@@ -146,7 +147,7 @@ Options (can also be set via environment variables):
                     unselected courses are hidden in the spawn UI. Empty (the
                     default) keeps the historical "all courses" behaviour.
                       all     - every course
-                      basic   - cpu base + gpu base only
+                      basic   - cpu/gpu base + code-server (code-cpu, code-gpu)
                       none    - Hub only, no courses
                       <list>  - comma-separated keys, e.g. cpu,gpu,Course-CV
                     Env: AUPLC_COURSES
@@ -176,7 +177,7 @@ Options (can also be set via environment variables):
     ./auplc-installer install --gpu=strix-halo
     ./auplc-installer install --gpu=auto --dry-run
     ./auplc-installer install --gpu=phx --docker=0     # legacy flags
-    ./auplc-installer install --courses=basic          # cpu + gpu only
+    ./auplc-installer install --courses=basic          # base + code-server envs
     ./auplc-installer install --courses=cpu,gpu,Course-CV
     ./auplc-installer img build base-rocm --gpu=strix
     ./auplc-installer install --mirror=mirror.example.com
@@ -565,17 +566,19 @@ def cmd_dev_quick(state: InstallerState) -> None:
     log("Dev quick cycle: build hub → restart pod")
     log("===========================================")
     detect_and_configure_gpu(state.gpu, gpu_type_override=state.gpu_type)
-    local_image_build(
-        ["hub"],
-        cfg=state.gpu,
-        courses=state.courses,
-        mirror_prefix=state.mirror_prefix,
-        mirror_pip=state.mirror_pip,
-        mirror_npm=state.mirror_npm,
-        use_docker=state.use_docker,
-        k3s_images_dir=state.k3s_images_dir,
-    )
-    dev_quick_rollout()
+    with stage("Building Hub image", idx=1, total=2):
+        local_image_build(
+            ["hub"],
+            cfg=state.gpu,
+            courses=state.courses,
+            mirror_prefix=state.mirror_prefix,
+            mirror_pip=state.mirror_pip,
+            mirror_npm=state.mirror_npm,
+            use_docker=state.use_docker,
+            k3s_images_dir=state.k3s_images_dir,
+        )
+    with stage("Restarting Hub pod", idx=2, total=2):
+        dev_quick_rollout()
 
 
 def cmd_dev_deploy(state: InstallerState) -> None:
@@ -686,25 +689,29 @@ def cmd_rt_reinstall(state: InstallerState) -> None:
 
 def cmd_img_build(state: InstallerState, targets: Sequence[str]) -> None:
     detect_and_configure_gpu(state.gpu, gpu_type_override=state.gpu_type)
-    local_image_build(
-        targets,
-        cfg=state.gpu,
-        courses=state.courses,
-        mirror_prefix=state.mirror_prefix,
-        mirror_pip=state.mirror_pip,
-        mirror_npm=state.mirror_npm,
-        use_docker=state.use_docker,
-        k3s_images_dir=state.k3s_images_dir,
-    )
+    with stage("Building custom images", idx=1, total=1):
+        local_image_build(
+            targets,
+            cfg=state.gpu,
+            courses=state.courses,
+            mirror_prefix=state.mirror_prefix,
+            mirror_pip=state.mirror_pip,
+            mirror_npm=state.mirror_npm,
+            use_docker=state.use_docker,
+            k3s_images_dir=state.k3s_images_dir,
+        )
+    log_success("Custom images built successfully.")
 
 
 def cmd_img_pull(state: InstallerState) -> None:
-    pull_external_images(
-        skip_build_only=False,
-        use_docker=state.use_docker,
-        k3s_images_dir=state.k3s_images_dir,
-        mirror_prefix=state.mirror_prefix,
-    )
+    with stage("Pulling external images", idx=1, total=1):
+        pull_external_images(
+            skip_build_only=False,
+            use_docker=state.use_docker,
+            k3s_images_dir=state.k3s_images_dir,
+            mirror_prefix=state.mirror_prefix,
+        )
+    log_success("External images pulled successfully.")
 
 
 # ---------------------------------------------------------------------------
@@ -871,7 +878,7 @@ def _dispatch(
         else:
             log_error(
                 "Usage: auplc-installer img {build [target...]|pull}. "
-                "Targets: all, hub, base-cpu, base-rocm, cv, dl, llm, physim"
+                "Targets: all, hub, base-cpu, base-rocm, code, code-cpu, code-gpu, cv, dl, llm, physim"
             )
             sys.exit(1)
         return

--- a/auplc_installer/overlay.py
+++ b/auplc_installer/overlay.py
@@ -29,6 +29,7 @@ from auplc_installer.util import InstallerError, log
 # so YAML emission is deterministic.
 _RESOURCE_IMAGE_BASE: dict[str, str] = {
     "gpu": "auplc-base",
+    "code-gpu": "auplc-code-gpu",
     "Course-CV": "auplc-cv",
     "Course-DL": "auplc-dl",
     "Course-LLM": "auplc-llm",
@@ -62,7 +63,7 @@ def emit_overlay(
     if not homogeneous_target:
         targets = " ".join(s.gpu_target for s in cfg.skus)
         buf.write(f"# Mixed gfx targets: {targets}\n")
-    buf.write(f"# Course selection : {courses.description()}\n")
+    buf.write(f"# Env selection : {courses.description()}\n")
     buf.write("# Regenerated on install/upgrade.\n")
     buf.write("custom:\n")
 
@@ -188,7 +189,7 @@ def generate_values_overlay(
 # header by :func:`emit_overlay`. Used by upgrade flows so that a bare
 # ``rt upgrade`` (no ``--courses=`` flag) preserves whatever the user
 # originally installed with instead of silently expanding to "all".
-_COURSE_HEADER_RE = re.compile(r"^# Course selection\s*:\s*(.+?)\s*$")
+_COURSE_HEADER_RE = re.compile(r"^# (?:Env selection|Course selection)\s*:\s*(.+?)\s*$")
 
 
 def try_load_courses_from_overlay(overlay_path: Path) -> CourseSelection | None:

--- a/auplc_installer/summary.py
+++ b/auplc_installer/summary.py
@@ -68,7 +68,7 @@ def format_configuration_summary(state: InstallerState, *, image_source_label: s
     lines.append(f"  Registry mirror  : {state.mirror_prefix or '(none)'}")
     lines.append(f"  PyPI mirror      : {state.mirror_pip or '(default)'}")
     lines.append(f"  npm mirror       : {state.mirror_npm or '(default)'}")
-    lines.append(f"  Courses          : {state.courses.description()}")
+    lines.append(f"  Environments     : {state.courses.description()}")
     return "\n".join(lines)
 
 
@@ -104,5 +104,5 @@ def format_configuration_summary_colored(state: InstallerState, *, image_source_
         lines.append(row("npm mirror", state.mirror_npm))
     else:
         lines.append(row("npm mirror", "(default)", faint=True))
-    lines.append(row("Courses", state.courses.description(), accent=True))
+    lines.append(row("Environments", state.courses.description(), accent=True))
     return "\n".join(lines)

--- a/auplc_installer/tui.py
+++ b/auplc_installer/tui.py
@@ -571,41 +571,67 @@ def _flow_collect_mirrors(state: InstallerState) -> None:
     )
 
 
-def _flow_select_courses(state: InstallerState) -> None:
-    """Course selection: preset (all/basic/custom). Custom opens a checklist."""
-    current_label = state.courses.description()
-    preset = _ask_select(
-        f"Course selection — current: {current_label}",
-        (
-            Choice("all", "all    — every course (default; identical to current CLI behaviour)"),
-            Choice("basic", "basic  — cpu base + gpu base only"),
-            Choice("custom", "custom — pick courses individually"),
-        ),
-        default_value="all" if state.courses.is_default() else "custom",
-    )
-    if preset == "all":
-        state.courses = CourseSelection(picks=list(COURSE_PRESET_ALL))
-        return
-    if preset == "basic":
-        state.courses = CourseSelection(picks=list(COURSE_PRESET_BASIC))
-        return
+def _flow_select_envs(state: InstallerState, *, allow_back: bool = False) -> bool:
+    """Environment selection: preset (all/basic/custom). Custom opens a checklist.
 
-    # custom: checklist
-    choices = [Choice(c.key, f"{c.key:<14} - {c.display_name}") for c in COURSE_CATALOG]
-    if state.courses.is_default() or state.courses.is_none():
-        preselected: list[str] = list(COURSE_PRESET_ALL) if state.courses.is_default() else []
-    else:
-        preselected = list(state.courses.picks)
+    Returns ``True`` when the user confirms a selection, ``False`` when they
+    choose ``← Back`` on the preset menu (only offered when ``allow_back``).
+    """
+    while True:
+        current_label = state.courses.description()
+        preset_choices: list[Choice] = [
+            Choice("all", "all    — every environment (default)"),
+            Choice("basic", "basic  — base + code-server (cpu, gpu, code-cpu, code-gpu)"),
+            Choice("custom", "custom — pick environments individually"),
+        ]
+        if allow_back:
+            preset_choices.append(Choice("back", "← Back"))
 
-    picks = _ask_checkbox(
-        "Pick courses to install (space toggles, Enter confirms; nothing selected = Hub only)",
-        choices,
-        preselected=preselected,
-    )
-    if not picks:
-        state.courses = CourseSelection(picks=[NONE_SENTINEL])
-    else:
-        state.courses = CourseSelection(picks=picks)
+        preset = _ask_select(
+            f"Env selection — current: {current_label}",
+            preset_choices,
+            default_value="all" if state.courses.is_default() else "custom",
+        )
+        if preset == "back":
+            return False
+        if preset == "all":
+            state.courses = CourseSelection(picks=list(COURSE_PRESET_ALL))
+            return True
+        if preset == "basic":
+            state.courses = CourseSelection(picks=list(COURSE_PRESET_BASIC))
+            return True
+
+        # custom: checklist with an explicit path back to the preset menu
+        action = _ask_select(
+            "Custom env selection",
+            (
+                Choice("pick", "Pick environments (checkbox)"),
+                Choice("back", "← Back to presets"),
+            ),
+        )
+        if action == "back":
+            continue
+
+        choices = [Choice(c.key, f"{c.key:<14} - {c.display_name}") for c in COURSE_CATALOG]
+        if state.courses.is_default() or state.courses.is_none():
+            preselected: list[str] = list(COURSE_PRESET_ALL) if state.courses.is_default() else []
+        else:
+            preselected = list(state.courses.picks)
+
+        picks = _ask_checkbox(
+            "Pick environments to install (space toggles, Enter confirms; nothing selected = Hub only)",
+            choices,
+            preselected=preselected,
+        )
+        if not picks:
+            state.courses = CourseSelection(picks=[NONE_SENTINEL])
+        else:
+            state.courses = CourseSelection(picks=picks)
+        return True
+
+
+# Back-compat alias for any external callers.
+_flow_select_courses = _flow_select_envs
 
 
 # ---------------------------------------------------------------------------
@@ -623,20 +649,28 @@ def _flow_install(state: InstallerState) -> None:
         image_source_label = f"Offline bundle ({state.bundle_dir})"
         pull = False
     else:
-        image_source = _ask_select(
-            "Image source",
-            (
-                Choice("pull", "pull  - fetch pre-built images from registry (default)"),
-                Choice("build", "build - build from dockerfiles/ via Makefile"),
-            ),
-            default_value="pull",
-        )
-        image_source_label = image_source
-        pull = image_source == "pull"
-        _flow_collect_image_coords(state)
-        _flow_collect_mirrors(state)
+        while True:
+            image_source = _ask_select(
+                "Image source",
+                (
+                    Choice("pull", "pull  - fetch pre-built images from registry (default)"),
+                    Choice("build", "build - build from dockerfiles/ via Makefile"),
+                ),
+                default_value="pull",
+            )
+            image_source_label = image_source
+            pull = image_source == "pull"
+            _flow_collect_image_coords(state)
+            _flow_collect_mirrors(state)
+            if _flow_select_envs(state, allow_back=True):
+                break
 
-    _flow_select_courses(state)
+    if state.offline_mode:
+        while True:
+            if _flow_select_envs(state, allow_back=True):
+                break
+            # Back from env selection in offline mode returns to GPU step.
+            _flow_select_gpu(state)
 
     log("\n" + format_configuration_summary_colored(state, image_source_label=image_source_label) + "\n")
     if not _ask_confirm("Proceed with installation?", default=True):
@@ -663,9 +697,11 @@ def _flow_pack(state: InstallerState, source_root) -> None:
         ),
         default_value="pull",
     )
-    _flow_collect_image_coords(state)
-    _flow_collect_mirrors(state)
-    _flow_select_courses(state)
+    while True:
+        _flow_collect_image_coords(state)
+        _flow_collect_mirrors(state)
+        if _flow_select_envs(state, allow_back=True):
+            break
 
     log("\n" + format_configuration_summary_colored(state, image_source_label=pack_mode))
     log("\nThis will create an offline bundle archive in the current directory.")
@@ -703,24 +739,12 @@ def _flow_install_tools(state: InstallerState) -> None:
 def _flow_dev(state: InstallerState) -> None:
     """Dev sub-menu: pick one action, run it, then return.
 
-    ``upgrade`` does NOT re-prompt for courses — the previous selection
+    ``upgrade`` does NOT re-prompt for environments — the previous selection
     is preserved by ``cmd_dev_upgrade`` reading the existing overlay
     header. ``deploy`` / ``reinstall`` still ask because they're "fresh"
     from the user's point of view (a dev-overlay redeploy is allowed to
     change scope).
     """
-    sub = _ask_select(
-        "Dev mode",
-        (
-            Choice("quick", "quick     — rebuild Hub image and restart pod"),
-            Choice("deploy", "deploy    — install with dev overlay (student=admin)"),
-            Choice("upgrade", "upgrade   — helm upgrade with dev overlay"),
-            Choice("reinstall", "reinstall — uninstall + redeploy with dev overlay"),
-            Choice("cancel", "← Cancel (back to main menu)"),
-        ),
-    )
-    if sub == "cancel":
-        raise _CancelledError
     from auplc_installer.cli import (
         cmd_dev_deploy,
         cmd_dev_quick,
@@ -728,39 +752,50 @@ def _flow_dev(state: InstallerState) -> None:
         cmd_dev_upgrade,
     )
 
-    if sub == "quick":
-        cmd_dev_quick(state)
-    elif sub == "deploy":
-        _flow_select_courses(state)
-        cmd_dev_deploy(state)
-    elif sub == "upgrade":
-        # No course prompt: cmd_dev_upgrade preserves the previous selection.
-        cmd_dev_upgrade(state)
-    elif sub == "reinstall":
-        if not _ask_confirm("Uninstall and redeploy JupyterHub (dev overlay)?", default=False):
+    while True:
+        sub = _ask_select(
+            "Dev mode",
+            (
+                Choice("quick", "quick     — rebuild Hub image and restart pod"),
+                Choice("deploy", "deploy    — install with dev overlay (student=admin)"),
+                Choice("upgrade", "upgrade   — helm upgrade with dev overlay"),
+                Choice("reinstall", "reinstall — uninstall + redeploy with dev overlay"),
+                Choice("cancel", "← Cancel (back to main menu)"),
+            ),
+        )
+        if sub == "cancel":
             raise _CancelledError
-        _flow_select_courses(state)
-        cmd_dev_reinstall(state)
+
+        if sub == "quick":
+            cmd_dev_quick(state)
+            return
+        if sub == "upgrade":
+            cmd_dev_upgrade(state)
+            return
+        if sub == "deploy":
+            while True:
+                if _flow_select_envs(state, allow_back=True):
+                    cmd_dev_deploy(state)
+                    return
+                break
+            continue
+        if sub == "reinstall":
+            if not _ask_confirm("Uninstall and redeploy JupyterHub (dev overlay)?", default=False):
+                raise _CancelledError
+            while True:
+                if _flow_select_envs(state, allow_back=True):
+                    cmd_dev_reinstall(state)
+                    return
+                break
+            continue
 
 
 def _flow_rt(state: InstallerState) -> None:
     """Runtime (Helm-only) sub-menu: pick one action, run it, then return.
 
     See ``_flow_dev`` for the rationale on why ``upgrade`` skips the
-    course prompt.
+    environment prompt.
     """
-    sub = _ask_select(
-        "Runtime (Helm) only",
-        (
-            Choice("install", "install   — deploy JupyterHub"),
-            Choice("upgrade", "upgrade   — helm upgrade (for values changes)"),
-            Choice("reinstall", "reinstall — uninstall then redeploy"),
-            Choice("remove", "remove    — uninstall the Helm release"),
-            Choice("cancel", "← Cancel (back to main menu)"),
-        ),
-    )
-    if sub == "cancel":
-        raise _CancelledError
     from auplc_installer.cli import (
         cmd_rt_install,
         cmd_rt_reinstall,
@@ -768,42 +803,71 @@ def _flow_rt(state: InstallerState) -> None:
         cmd_rt_upgrade,
     )
 
-    if sub == "install":
-        _flow_select_courses(state)
-        cmd_rt_install(state)
-    elif sub == "upgrade":
-        # No course prompt: cmd_rt_upgrade preserves the previous selection.
-        cmd_rt_upgrade(state)
-    elif sub == "reinstall":
-        if not _ask_confirm("Uninstall and redeploy JupyterHub?", default=False):
+    while True:
+        sub = _ask_select(
+            "Runtime (Helm) only",
+            (
+                Choice("install", "install   — deploy JupyterHub"),
+                Choice("upgrade", "upgrade   — helm upgrade (for values changes)"),
+                Choice("reinstall", "reinstall — uninstall then redeploy"),
+                Choice("remove", "remove    — uninstall the Helm release"),
+                Choice("cancel", "← Cancel (back to main menu)"),
+            ),
+        )
+        if sub == "cancel":
             raise _CancelledError
-        _flow_select_courses(state)
-        cmd_rt_reinstall(state)
-    elif sub == "remove":
-        if not _ask_confirm("Uninstall the JupyterHub Helm release? (K3s remains.)", default=False):
-            raise _CancelledError
-        cmd_rt_remove(state)
+
+        if sub == "install":
+            while True:
+                if _flow_select_envs(state, allow_back=True):
+                    cmd_rt_install(state)
+                    return
+                break
+            continue
+        if sub == "upgrade":
+            cmd_rt_upgrade(state)
+            return
+        if sub == "reinstall":
+            if not _ask_confirm("Uninstall and redeploy JupyterHub?", default=False):
+                raise _CancelledError
+            while True:
+                if _flow_select_envs(state, allow_back=True):
+                    cmd_rt_reinstall(state)
+                    return
+                break
+            continue
+        if sub == "remove":
+            if not _ask_confirm("Uninstall the JupyterHub Helm release? (K3s remains.)", default=False):
+                raise _CancelledError
+            cmd_rt_remove(state)
+            return
 
 
 def _flow_img(state: InstallerState) -> None:
     """Image management sub-menu: pick one action, run it, then return."""
-    sub = _ask_select(
-        "Image management",
-        (
-            Choice("build", "build — build custom images via Makefile"),
-            Choice("pull", "pull  — pull external images for offline use"),
-            Choice("cancel", "← Cancel (back to main menu)"),
-        ),
-    )
-    if sub == "cancel":
-        raise _CancelledError
     from auplc_installer.cli import cmd_img_build, cmd_img_pull
 
-    if sub == "build":
-        _flow_select_courses(state)
-        cmd_img_build(state, [])
-    elif sub == "pull":
-        cmd_img_pull(state)
+    while True:
+        sub = _ask_select(
+            "Image management",
+            (
+                Choice("build", "build — build custom images via Makefile"),
+                Choice("pull", "pull  — pull external images for offline use"),
+                Choice("cancel", "← Cancel (back to main menu)"),
+            ),
+        )
+        if sub == "cancel":
+            raise _CancelledError
+        if sub == "pull":
+            cmd_img_pull(state)
+            return
+        if sub == "build":
+            while True:
+                if _flow_select_envs(state, allow_back=True):
+                    cmd_img_build(state, [])
+                    return
+                break
+            continue
 
 
 # ---------------------------------------------------------------------------

--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -43,7 +43,7 @@ endif
 .PHONY: all base base-cpu base-rocm base-gfx1151 hub code code-cpu code-gpu courses cv dl llm physim
 
 # Build all images
-all: base hub courses
+all: base hub code courses
 
 # --- Base Images ---
 base: base-cpu base-rocm

--- a/tests/installer/test_catalog.py
+++ b/tests/installer/test_catalog.py
@@ -34,10 +34,7 @@ class ParseSelectionSpecTests(unittest.TestCase):
         self.assertFalse(sel.is_default())  # explicit selection, not the default sentinel
 
     def test_basic_keyword_picks_cpu_gpu_and_code_server(self) -> None:
-        self.assertEqual(
-            parse_selection_spec("basic").picks,
-            ["cpu", "gpu", "code-cpu", "code-gpu"],
-        )
+        self.assertEqual(parse_selection_spec("basic").picks, list(COURSE_PRESET_BASIC))
 
     def test_none_keyword_uses_sentinel(self) -> None:
         sel = parse_selection_spec("none")

--- a/tests/installer/test_catalog.py
+++ b/tests/installer/test_catalog.py
@@ -33,8 +33,11 @@ class ParseSelectionSpecTests(unittest.TestCase):
         self.assertEqual(sel.picks, list(COURSE_PRESET_ALL))
         self.assertFalse(sel.is_default())  # explicit selection, not the default sentinel
 
-    def test_basic_keyword_picks_cpu_and_gpu_only(self) -> None:
-        self.assertEqual(parse_selection_spec("basic").picks, list(COURSE_PRESET_BASIC))
+    def test_basic_keyword_picks_cpu_gpu_and_code_server(self) -> None:
+        self.assertEqual(
+            parse_selection_spec("basic").picks,
+            ["cpu", "gpu", "code-cpu", "code-gpu"],
+        )
 
     def test_none_keyword_uses_sentinel(self) -> None:
         sel = parse_selection_spec("none")
@@ -88,14 +91,17 @@ class CourseSelectionTests(unittest.TestCase):
         self.assertEqual(sel.effective_keys(), ["Course-LLM", "cpu"])
 
     def test_gpu_image_basenames_only_returns_gpu_required(self) -> None:
-        sel = CourseSelection(picks=["cpu", "gpu", "Course-CV"])
-        # cpu is plain-tagged, gpu/Course-CV are GPU-tagged
-        self.assertEqual(sel.gpu_image_basenames(), ["auplc-base", "auplc-cv"])
+        sel = CourseSelection(picks=["cpu", "gpu", "code-gpu", "Course-CV"])
+        # cpu/code-cpu are plain-tagged; gpu/code-gpu/Course-CV are GPU-tagged
+        self.assertEqual(
+            sel.gpu_image_basenames(),
+            ["auplc-base", "auplc-code-gpu", "auplc-cv"],
+        )
         self.assertEqual(sel.plain_image_basenames(), ["auplc-default"])
 
     def test_make_targets_includes_every_selected_course(self) -> None:
-        sel = CourseSelection(picks=["cpu", "Course-DL"])
-        self.assertEqual(sel.make_targets(), ["base-cpu", "dl"])
+        sel = CourseSelection(picks=["cpu", "code-cpu", "Course-DL"])
+        self.assertEqual(sel.make_targets(), ["base-cpu", "code-cpu", "dl"])
 
     def test_description_default(self) -> None:
         self.assertEqual(CourseSelection.default().description(), "all (default)")

--- a/tests/installer/test_overlay.py
+++ b/tests/installer/test_overlay.py
@@ -69,6 +69,7 @@ class OverlayDefaultSelectionTests(unittest.TestCase):
         _, parsed = _render(_strix_halo_cfg(), courses=CourseSelection.default())
         images = parsed["custom"]["resources"]["images"]
         self.assertEqual(images["gpu"], "ghcr.io/amdresearch/auplc-base:v1.0-gfx1151")
+        self.assertEqual(images["code-gpu"], "ghcr.io/amdresearch/auplc-code-gpu:v1.0-gfx1151")
         self.assertEqual(images["Course-CV"], "ghcr.io/amdresearch/auplc-cv:v1.0-gfx1151")
         self.assertEqual(images["Course-PhySim"], "ghcr.io/amdresearch/auplc-physim:v1.0-gfx1151")
 
@@ -89,11 +90,8 @@ class OverlayBasicSelectionTests(unittest.TestCase):
             courses=CourseSelection(picks=list(COURSE_PRESET_BASIC)),
         )
         mapping = parsed["custom"]["teams"]["mapping"]
-        # The 'gpu' team's full base list is the four GPU courses; with the
-        # basic preset (cpu+gpu) none of those overlap, so it must be empty.
-        self.assertEqual(mapping["gpu"], [])
-        # The 'cpu' team's only base entry IS 'cpu', so it survives.
-        self.assertEqual(mapping["cpu"], ["cpu"])
+        self.assertEqual(mapping["cpu"], ["cpu", "code-cpu"])
+        self.assertEqual(mapping["gpu"], ["code-gpu"])
 
     def test_basic_omits_unselected_resource_images(self) -> None:
         _, parsed = _render(
@@ -101,7 +99,8 @@ class OverlayBasicSelectionTests(unittest.TestCase):
             courses=CourseSelection(picks=list(COURSE_PRESET_BASIC)),
         )
         images = parsed["custom"]["resources"]["images"]
-        self.assertIn("gpu", images)  # 'gpu' is selected via the basic preset
+        self.assertIn("gpu", images)
+        self.assertIn("code-gpu", images)
         self.assertNotIn("Course-CV", images)
         self.assertNotIn("Course-LLM", images)
 
@@ -260,11 +259,20 @@ class TryLoadCoursesFromOverlayTests(unittest.TestCase):
             )
             return try_load_courses_from_overlay(path)
 
-    def test_default_round_trips(self) -> None:
+    def test_env_selection_header_round_trips(self) -> None:
         loaded = self._write_and_read_back(CourseSelection.default())
         self.assertIsNotNone(loaded)
         assert loaded is not None
         self.assertTrue(loaded.is_default())
+
+    def test_legacy_course_selection_header_still_loads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "values.local.yaml"
+            path.write_text("# Course selection : cpu, gpu\ncustom: {}\n", encoding="utf-8")
+            loaded = try_load_courses_from_overlay(path)
+            self.assertIsNotNone(loaded)
+            assert loaded is not None
+            self.assertEqual(loaded.picks, ["cpu", "gpu"])
 
     def test_basic_preset_round_trips(self) -> None:
         original = CourseSelection(picks=list(COURSE_PRESET_BASIC))


### PR DESCRIPTION
## Summary
- Register `code-cpu` and `code-gpu` in the installer catalog, team mapping, overlay GPU image tags, and Makefile `all` so install/build/pack flows pull or build code-server images.
- Expand the `basic` preset to include base + code-server environments; rename TUI/CLI wording from course selection to env selection with back navigation in nested menus.
- Show progress output during standalone `img build`/`img pull` and `dev quick` by wrapping those flows in installer progress stages.

## Test plan
- [x] `python3 -m pytest tests/installer/ -q` (105 passed)
- [x] `./auplc-installer img build code -v` builds `auplc-code-cpu` and `auplc-code-gpu`
- [ ] `./auplc-installer tui` → Image management → build → basic shows live build progress
- [ ] `./auplc-installer install --courses=basic --dry-run` lists cpu/gpu/code-cpu/code-gpu environments


Made with [Cursor](https://cursor.com)