### PR TITLE
feat: Add Code image developer toolchain

### DIFF
--- a/dockerfiles/Code/Dockerfile
+++ b/dockerfiles/Code/Dockerfile
@@ -17,12 +17,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-ARG NODE_IMAGE=docker.io/library/node:20-bookworm-slim
+ARG NODE_IMAGE=docker.io/library/node:22-bookworm-slim
 ARG BASE_IMAGE=ghcr.io/amdresearch/auplc-default:latest
 ARG IMAGE_FLAVOR=cpu
 ARG CODE_SERVER_VERSION=4.96.4
 
-FROM ${NODE_IMAGE} AS hub-link-builder
+FROM ${NODE_IMAGE} AS node-runtime
+
+FROM node-runtime AS hub-link-builder
 
 ARG NPM_REGISTRY=
 WORKDIR /build/auplc-hub-link
@@ -39,15 +41,34 @@ FROM ${BASE_IMAGE}
 
 ARG CODE_SERVER_VERSION=4.96.4
 ARG IMAGE_FLAVOR
+ARG NPM_REGISTRY=
+ARG PNPM_VERSION=10.27.0
+ARG CODE_GLOBAL_NPM_PACKAGES
+ARG PIXI_VERSION=v0.68.1
+ARG PIXI_DOWNLOAD_URL=
+ARG PIXI_CONDA_FORGE_MIRROR=https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl git nginx-light && \
-    curl -fsSL -o /tmp/code-server.deb https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_amd64.deb && \
-    apt-get install -y --no-install-recommends /tmp/code-server.deb && \
-    rm -f /tmp/code-server.deb && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+COPY packages/code-common-apt.txt /opt/auplc/build/code-common-apt.txt
+COPY scripts/install-code-system-packages.sh scripts/install-node-toolchain.sh scripts/install-pixi-toolchain.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/install-code-system-packages.sh /usr/local/bin/install-node-toolchain.sh /usr/local/bin/install-pixi-toolchain.sh && \
+    /usr/local/bin/install-code-system-packages.sh /opt/auplc/build/code-common-apt.txt
+
+RUN /usr/local/bin/install-pixi-toolchain.sh
+
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
+    ln -sf ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
+
+RUN /usr/local/bin/install-node-toolchain.sh
+
+ENV NPM_CONFIG_PREFIX=/home/jovyan/.local
+ENV PIXI_HOME=/home/jovyan/.pixi
+ENV PATH=/home/jovyan/.local/bin:/home/jovyan/.pixi/bin:${PATH}
 
 COPY extensions.txt /opt/auplc/extensions/extensions.txt
 COPY extensions/ /opt/auplc/extensions/local/
@@ -60,8 +81,11 @@ RUN chmod +x /usr/local/bin/start-code-server.sh && \
         /opt/auplc/code-server/extensions \
         /home/jovyan/.cache \
         /home/jovyan/.config \
-        /home/jovyan/.local/share/code-server && \
-    chown -R jovyan:100 /opt/auplc /home/jovyan/.cache /home/jovyan/.config /home/jovyan/.local
+        /home/jovyan/.local/bin \
+        /home/jovyan/.local/share/code-server \
+        /home/jovyan/.pixi/bin \
+        /home/jovyan/.npm && \
+    chown -R jovyan:100 /opt/auplc /home/jovyan/.cache /home/jovyan/.config /home/jovyan/.local /home/jovyan/.pixi /home/jovyan/.npm
 
 USER jovyan
 

--- a/dockerfiles/Code/README.md
+++ b/dockerfiles/Code/README.md
@@ -32,6 +32,12 @@ The coding environments are intentionally generic:
 - Existing `auplc-default`, `auplc-base`, and `Course-*` images remain notebook/course-focused.
 - Course-specific VS Code image families are not part of this workflow.
 
+The Code images are the shared developer-toolchain layer. Put browser editor,
+Node.js, TypeScript/frontend, and native build tooling here instead of adding
+those tools to Base notebook images or Course images. CPU and GPU Code images
+are built from the same Dockerfile and differ only by `BASE_IMAGE`, so the Code
+layer stays consistent across hardware targets.
+
 The default Hub resource keys are `code-cpu` and `code-gpu`. Code-server launch behavior is configured through `custom.resources.metadata.<resource>.launchMode: code-server`, alongside the same `custom.resources.images`, `custom.resources.requirements`, and `custom.teams.mapping` model as notebook resources in `runtime/values.yaml`.
 
 ## Build Commands
@@ -48,6 +54,33 @@ make -C dockerfiles code
 
 The Dockerfile pins code-server to version `4.96.4` so builds use a known editor runtime instead of silently changing when a new upstream release appears.
 
+Additional build arguments customize the shared development toolchain:
+
+- `NODE_IMAGE` selects the upstream Node.js image stage. The final image copies
+  Node.js, `npm`, `npx`, `corepack`, and the bundled global Node modules from
+  this stage instead of configuring a NodeSource or apt Node repository. The
+  default is `docker.io/library/node:22-bookworm-slim`.
+- `PNPM_VERSION` pins the `pnpm` version prepared through `corepack` and
+  installed globally for runtime users. The default is `10.27.0`.
+- `CODE_GLOBAL_NPM_PACKAGES` is a space-separated list of small global JS/TS
+  tools installed into the Code image. The default is
+  `typescript tsx vite eslint prettier`.
+- `NPM_REGISTRY` configures the npm registry mirror for both the extension
+  builder stage and the final Node toolchain install.
+- `PIXI_VERSION` pins the Pixi binary installed into `/usr/local/bin`. The
+  default is `v0.68.1`.
+- `PIXI_DOWNLOAD_URL` overrides the Pixi binary URL, which is useful when the
+  build environment must download Pixi from an approved mirror instead of
+  GitHub releases.
+- `PIXI_CONDA_FORGE_MIRROR` configures Pixi's conda-forge channel mirror. The
+  default is Tsinghua TUNA's public mirror at
+  `https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge`. Set this
+  to an internal or regional mirror when required by local policy.
+
+Common apt packages for the Code layer are listed in
+`packages/code-common-apt.txt`. Keep package additions there so CPU and GPU Code
+images continue to share one package set and the Dockerfile remains small.
+
 ## Runtime Behavior
 
 The start script launches:
@@ -63,8 +96,35 @@ code-server on loopback. The proxy must preserve the full browser `Host` value
 with `X-Forwarded-Host` so code-server's WebSocket origin check succeeds behind
 JupyterHub and NodePort-style local URLs.
 
-Git is installed in the image so cloned projects can use source control from the
-integrated terminal and editor UI without additional setup.
+Git, Node.js LTS, `npm`, `npx`, `corepack`, pinned `pnpm`, TypeScript/frontend
+helpers, Pixi, and native build tools are installed in the image so cloned
+projects can use source control, frontend workflows, sudo-free user package
+management, and native npm package builds from the integrated terminal and
+editor UI without additional setup.
+
+The Code images also route user-level global npm installs into the persistent
+home directory instead of `/usr/local`: `NPM_CONFIG_PREFIX` defaults to
+`/home/jovyan/.local`, and `/home/jovyan/.local/bin` is prepended to `PATH`.
+This lets users install small project CLIs with commands such as
+`npm install -g cowsay` without sudo or write access to system directories.
+
+Pixi is provided as the sudo-free, apt-like package manager for user-space
+native tools and project environments. The image writes `/etc/pixi/config.toml`
+so requests for `https://conda.anaconda.org/conda-forge` are redirected to the
+configured mirror and no direct upstream fallback is listed by default. Users can
+create reproducible project environments with commands such as:
+
+```bash
+pixi init my-lab
+cd my-lab
+pixi add cmake pkg-config openssl zlib jq ripgrep
+pixi run jq --version
+```
+
+Pixi remains a user-space package manager. It does not replace image rebuilds or
+cluster administration for kernel modules, GPU/NPU drivers, device plugins,
+udev rules, system services, or packages that must write to root-owned system
+directories.
 
 Extensions are installed into `/opt/auplc/code-server/extensions` during image
 build. At runtime, code-server uses the persistent user extension directory

--- a/dockerfiles/Code/build.sh
+++ b/dockerfiles/Code/build.sh
@@ -19,8 +19,10 @@ case "${IMAGE_FLAVOR}" in
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NODE_IMAGE="${NODE_IMAGE:-docker.io/library/node:20-bookworm-slim}"
+NODE_IMAGE="${NODE_IMAGE:-docker.io/library/node:22-bookworm-slim}"
 NPM_REGISTRY="${NPM_REGISTRY:-}"
+PNPM_VERSION="${PNPM_VERSION:-10.27.0}"
+CODE_GLOBAL_NPM_PACKAGES="${CODE_GLOBAL_NPM_PACKAGES:-typescript tsx vite eslint prettier}"
 
 docker build \
   -f "${SCRIPT_DIR}/Dockerfile" \
@@ -28,5 +30,7 @@ docker build \
   --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
   --build-arg "IMAGE_FLAVOR=${IMAGE_FLAVOR}" \
   --build-arg "NPM_REGISTRY=${NPM_REGISTRY}" \
+  --build-arg "PNPM_VERSION=${PNPM_VERSION}" \
+  --build-arg "CODE_GLOBAL_NPM_PACKAGES=${CODE_GLOBAL_NPM_PACKAGES}" \
   -t "${IMAGE_TAG}" \
   "${SCRIPT_DIR}"

--- a/dockerfiles/Code/packages/code-common-apt.txt
+++ b/dockerfiles/Code/packages/code-common-apt.txt
@@ -1,0 +1,9 @@
+ca-certificates
+curl
+git
+nginx-light
+build-essential
+python3-dev
+cmake
+pkg-config
+ninja-build

--- a/dockerfiles/Code/scripts/install-code-system-packages.sh
+++ b/dockerfiles/Code/scripts/install-code-system-packages.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apt_packages_file="${1:?apt package list path is required}"
+code_server_version="${CODE_SERVER_VERSION:?CODE_SERVER_VERSION is required}"
+code_server_deb="/tmp/code-server.deb"
+packages=()
+
+while IFS= read -r package_name || [ -n "${package_name}" ]; do
+  package_name="${package_name%%#*}"
+  package_name="${package_name#"${package_name%%[![:space:]]*}"}"
+  package_name="${package_name%"${package_name##*[![:space:]]}"}"
+
+  if [ -n "${package_name}" ]; then
+    packages+=("${package_name}")
+  fi
+done <"${apt_packages_file}"
+
+apt-get update
+apt-get install -y --no-install-recommends "${packages[@]}"
+curl -fsSL \
+  -o "${code_server_deb}" \
+  "https://github.com/coder/code-server/releases/download/v${code_server_version}/code-server_${code_server_version}_amd64.deb"
+apt-get install -y --no-install-recommends "${code_server_deb}"
+rm -f "${code_server_deb}"
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Code/scripts/install-node-toolchain.sh
+++ b/dockerfiles/Code/scripts/install-node-toolchain.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pnpm_version="${PNPM_VERSION:?PNPM_VERSION is required}"
+npm_registry="${NPM_REGISTRY:-}"
+global_packages="${CODE_GLOBAL_NPM_PACKAGES:-typescript tsx vite eslint prettier}"
+global_package_args=()
+
+if [ -n "${npm_registry}" ]; then
+  npm config set registry "${npm_registry}"
+  export COREPACK_NPM_REGISTRY="${npm_registry}"
+fi
+
+corepack enable
+corepack prepare "pnpm@${pnpm_version}" --activate
+npm install -g --omit=dev --force "pnpm@${pnpm_version}"
+
+if [ -n "${global_packages}" ]; then
+  read -r -a global_package_args <<<"${global_packages}"
+  npm install -g --omit=dev "${global_package_args[@]}"
+fi
+
+node --version
+npm --version
+npx --version
+pnpm --version

--- a/dockerfiles/Code/scripts/install-pixi-toolchain.sh
+++ b/dockerfiles/Code/scripts/install-pixi-toolchain.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pixi_version="${PIXI_VERSION:-v0.68.1}"
+pixi_download_url="${PIXI_DOWNLOAD_URL:-}"
+pixi_conda_forge_mirror="${PIXI_CONDA_FORGE_MIRROR:-https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge}"
+
+if [ -z "${pixi_download_url}" ]; then
+  case "$(uname -m)" in
+    x86_64) pixi_arch="x86_64" ;;
+    aarch64) pixi_arch="aarch64" ;;
+    *)
+      printf 'Unsupported Pixi architecture: %s\n' "$(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  pixi_download_url="https://github.com/prefix-dev/pixi/releases/download/${pixi_version}/pixi-${pixi_arch}-unknown-linux-musl"
+fi
+
+curl -fsSL --compressed -o /usr/local/bin/pixi "${pixi_download_url}"
+chmod +x /usr/local/bin/pixi
+
+mkdir -p /etc/pixi
+if [ -n "${pixi_conda_forge_mirror}" ]; then
+  cat >/etc/pixi/config.toml <<EOF
+tls-root-certs = "native"
+default-channels = ["conda-forge"]
+
+[mirrors]
+"https://conda.anaconda.org/conda-forge" = [
+  "${pixi_conda_forge_mirror}",
+]
+EOF
+else
+  cat >/etc/pixi/config.toml <<'EOF'
+tls-root-certs = "native"
+default-channels = ["conda-forge"]
+EOF
+fi
+
+pixi --version

--- a/dockerfiles/Code/start-code-server.sh
+++ b/dockerfiles/Code/start-code-server.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 export USER="${USER:-jovyan}"
 export SHELL="${SHELL:-/bin/bash}"
+export PIXI_HOME="${PIXI_HOME:-${HOME:-/home/jovyan}/.pixi}"
+export PATH="${HOME:-/home/jovyan}/.local/bin:${PIXI_HOME}/bin:${PATH}"
+export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-${HOME:-/home/jovyan}/.local}"
 
 public_port="${PORT:-8888}"
 code_server_port="${AUPLC_CODE_SERVER_PORT:-8889}"
@@ -11,6 +14,10 @@ workdir="${AUPLC_CODE_WORKDIR:-/home/jovyan}"
 extensions_list="${AUPLC_CODE_EXTENSIONS_LIST:-/opt/auplc/extensions/extensions.txt}"
 local_extensions_dir="${AUPLC_CODE_LOCAL_EXTENSIONS_DIR:-/opt/auplc/extensions/local}"
 extensions_dir="${AUPLC_CODE_EXTENSIONS_DIR:-/home/jovyan/.local/share/code-server/extensions}"
+
+mkdir -p "${NPM_CONFIG_PREFIX}/bin"
+mkdir -p "${PIXI_HOME}/bin"
+npm config set prefix "${NPM_CONFIG_PREFIX}" >/dev/null
 
 url_decode() {
   local value="${1//+/ }"

--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -93,7 +93,7 @@ code-cpu:
 
 	cd Code && IMAGE_FLAVOR=cpu \
 		BASE_IMAGE=ghcr.io/amdresearch/auplc-default:latest \
-		NODE_IMAGE="$(if $(MIRROR_PREFIX),$(MIRROR_PREFIX)/docker.io/library/node:20-bookworm-slim,)" \
+		NODE_IMAGE="$(if $(MIRROR_PREFIX),$(MIRROR_PREFIX)/docker.io/library/node:22-bookworm-slim,)" \
 		NPM_REGISTRY="$(MIRROR_NPM)" \
 		bash ./build.sh
 	$(MAKE) save-image IMAGE=ghcr.io/amdresearch/auplc-code-cpu:latest
@@ -105,7 +105,7 @@ code-gpu:
 
 	cd Code && IMAGE_FLAVOR=gpu \
 		BASE_IMAGE=$(CODE_GPU_BASE_IMAGE) \
-		NODE_IMAGE="$(if $(MIRROR_PREFIX),$(MIRROR_PREFIX)/docker.io/library/node:20-bookworm-slim,)" \
+		NODE_IMAGE="$(if $(MIRROR_PREFIX),$(MIRROR_PREFIX)/docker.io/library/node:22-bookworm-slim,)" \
 		NPM_REGISTRY="$(MIRROR_NPM)" \
 		bash ./build.sh
 	docker tag ghcr.io/amdresearch/auplc-code-gpu:latest ghcr.io/amdresearch/auplc-code-gpu:latest-$(GPU_TARGET)


### PR DESCRIPTION
## Summary
- Add a shared Code image developer toolchain with Node.js 22, pinned pnpm, TypeScript/frontend helpers, and native build packages for CPU and GPU code-server images.
- Configure user-level global npm installs under `/home/jovyan/.local` so students can install small JS/TS CLIs without sudo or writes to `/usr/local`.
- Add Pixi as the sudo-free apt-like user package manager, with conda-forge requests redirected to the Tsinghua TUNA public mirror by default and build args for alternate mirrors.

## Test plan
- [x] `bash -n dockerfiles/Code/start-code-server.sh dockerfiles/Code/scripts/*.sh`
- [x] `docker build --check -f dockerfiles/Code/Dockerfile --build-arg BASE_IMAGE=ghcr.io/amdresearch/auplc-default:latest --build-arg NODE_IMAGE=docker.io/library/node:22-bookworm-slim dockerfiles/Code`
- [x] `make -C dockerfiles code-cpu`
- [x] `make -C dockerfiles code-gpu GPU_TARGET=gfx1151`
- [x] CPU image smoke test: `pixi global install jq`, `jq --version`, `npm install -g cowsay@1.6.0`
- [x] GPU image smoke test: `pixi global install jq`, `jq --version`, Node/pnpm version checks
