### PR TITLE
ci: expand Docker build disk cleanup

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -194,6 +194,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -260,6 +271,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -273,6 +295,13 @@ jobs:
           rm -f dockerfiles/Code/auplc-hub-link/auplc-hub-link-0.0.0.vsix
           npm --prefix dockerfiles/Code/auplc-hub-link run package
           test -f dockerfiles/Code/auplc-hub-link/auplc-hub-link-0.0.0.vsix
+
+      - name: Clean Hub link build artifacts
+        if: always()
+        run: |
+          rm -rf dockerfiles/Code/auplc-hub-link/node_modules
+          rm -rf dockerfiles/Code/auplc-hub-link/out
+          npm cache clean --force
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -328,6 +357,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -397,6 +437,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -410,6 +461,13 @@ jobs:
           rm -f dockerfiles/Code/auplc-hub-link/auplc-hub-link-0.0.0.vsix
           npm --prefix dockerfiles/Code/auplc-hub-link run package
           test -f dockerfiles/Code/auplc-hub-link/auplc-hub-link-0.0.0.vsix
+
+      - name: Clean Hub link build artifacts
+        if: always()
+        run: |
+          rm -rf dockerfiles/Code/auplc-hub-link/node_modules
+          rm -rf dockerfiles/Code/auplc-hub-link/out
+          npm cache clean --force
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -650,6 +708,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -753,3 +822,7 @@ jobs:
           cache-from: type=gha,scope=course-${{ matrix.course }}-${{ matrix.gpu_target }}
           cache-to: type=gha,mode=max,scope=course-${{ matrix.course }}-${{ matrix.gpu_target }}
           provenance: false
+
+      - name: Clean course build context
+        if: always()
+        run: rm -rf dockerfiles/Courses/${{ matrix.course }}/course_data

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -214,7 +214,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker metadata
         id: meta
@@ -312,7 +312,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker metadata
         id: meta
@@ -378,7 +378,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker metadata
         id: meta
@@ -478,7 +478,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker metadata (target-suffixed tags)
         id: meta-suffixed
@@ -590,7 +590,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve GPU config
         id: suffix
@@ -727,7 +727,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare build context
         run: cp -r projects/${{ matrix.course }} dockerfiles/Courses/${{ matrix.course }}/course_data

--- a/.github/workflows/pack-bundle.yml
+++ b/.github/workflows/pack-bundle.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve image tag and registry
         id: tag
@@ -195,7 +195,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve image tag
         id: tag
@@ -225,4 +225,3 @@ jobs:
           path: auplc-bundle-*.tar.gz
           retention-days: 7
           compression-level: 0  # already compressed
-


### PR DESCRIPTION
## Summary
- add the existing free-disk-space cleanup step to Docker image build jobs that did not have it
- clean temporary Hub link build artifacts after packaging the VSIX for code images
- add cleanup for copied course_data in course image builds, since course builds can also hit runner disk pressure
- make the course cleanup steps explicit in the matrix job so CV, DL, LLM, and PhySim each show course image cleanup in Actions
- remove the old GH_PACKAGES_TOKEN fallback and use the repository GITHUB_TOKEN for GHCR login steps

## Validation
- parsed .github/workflows/docker-build.yml and .github/workflows/pack-bundle.yml successfully with Python YAML loader
- triggered fork workflow for code-gpu/gfx1150 on MioYuuIH/aup-learning-cloud; new cleanup, Node setup, Hub link packaging cleanup, and Buildx setup all passed
- fork run stopped at GHCR login with ghcr.io/v2 denied before this token cleanup follow-up; the cleanup steps themselves were validated before that point

Fork test run: https://github.com/MioYuuIH/aup-learning-cloud/actions/runs/27112835356