### PR TITLE
test(installer): migrate unit tests from unittest to pytest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,10 +34,10 @@ jobs:
           python-version: '3.10'
 
       - name: Install test deps
-        run: pip install pyyaml
+        run: pip install pytest pyyaml
 
       - name: Run installer unit tests
-        run: python -m unittest discover tests/installer -v
+        run: python -m pytest tests/installer -v
 
   frontend-lint:
     name: Frontend (ESLint + TypeScript)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,14 @@ installer = [
     "questionary>=2.0.1",
     "prompt_toolkit>=3.0.43",
 ]
+test = [
+    "pytest>=8.0",
+    "pyyaml>=6.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests/installer"]
+pythonpath = ["."]
 
 [tool.ruff]
 # Target Python version

--- a/tests/installer/__init__.py
+++ b/tests/installer/__init__.py
@@ -5,7 +5,7 @@
 
 Run from the repository root with:
 
-    python3 -m unittest discover tests/installer
+    python -m pytest tests/installer
 
 These tests focus on pure-function logic (catalog parsing, overlay emission,
 GPU SKU resolution, manifest round-trip, image-ref normalisation) so they

--- a/tests/installer/conftest.py
+++ b/tests/installer/conftest.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Portions of this file consist of AI-generated content.
+
+"""Shared pytest fixtures for auplc-installer unit tests."""
+
+from __future__ import annotations

--- a/tests/installer/test_catalog.py
+++ b/tests/installer/test_catalog.py
@@ -11,7 +11,7 @@ overrides.
 
 from __future__ import annotations
 
-import unittest
+import pytest
 
 from auplc_installer.catalog import (
     COURSE_KEYS_ALL,
@@ -24,92 +24,97 @@ from auplc_installer.catalog import (
 from auplc_installer.util import InstallerError
 
 
-class ParseSelectionSpecTests(unittest.TestCase):
-    def test_empty_string_is_default(self) -> None:
-        self.assertTrue(parse_selection_spec("").is_default())
-
-    def test_all_keyword_picks_every_course(self) -> None:
-        sel = parse_selection_spec("all")
-        self.assertEqual(sel.picks, list(COURSE_PRESET_ALL))
-        self.assertFalse(sel.is_default())  # explicit selection, not the default sentinel
-
-    def test_basic_keyword_picks_cpu_gpu_and_code_server(self) -> None:
-        self.assertEqual(parse_selection_spec("basic").picks, list(COURSE_PRESET_BASIC))
-
-    def test_none_keyword_uses_sentinel(self) -> None:
-        sel = parse_selection_spec("none")
-        self.assertTrue(sel.is_none())
-        self.assertEqual(sel.picks, [NONE_SENTINEL])
-
-    def test_keyword_is_case_insensitive(self) -> None:
-        for spec in ("ALL", "All", "Basic", "NONE"):
-            with self.subTest(spec=spec):
-                # Should not raise
-                parse_selection_spec(spec)
-
-    def test_explicit_keys_round_trip(self) -> None:
-        sel = parse_selection_spec("cpu,gpu,Course-CV")
-        self.assertEqual(sel.picks, ["cpu", "gpu", "Course-CV"])
-
-    def test_tolerates_whitespace_and_blank_entries(self) -> None:
-        sel = parse_selection_spec("  cpu , ,Course-CV ")
-        self.assertEqual(sel.picks, ["cpu", "Course-CV"])
-
-    def test_unknown_key_raises(self) -> None:
-        with self.assertRaises(InstallerError):
-            parse_selection_spec("not-a-real-course")
-
-    def test_unknown_key_message_lists_valid_keys(self) -> None:
-        try:
-            parse_selection_spec("nope")
-        except InstallerError as exc:
-            msg = str(exc)
-            self.assertIn("nope", msg)
-            for key in COURSE_KEYS_ALL:
-                self.assertIn(key, msg)
-        else:
-            self.fail("expected InstallerError")
+def test_empty_string_is_default() -> None:
+    assert parse_selection_spec("").is_default()
 
 
-class CourseSelectionTests(unittest.TestCase):
-    def test_default_returns_all_keys(self) -> None:
-        sel = CourseSelection.default()
-        self.assertEqual(sel.effective_keys(), list(COURSE_KEYS_ALL))
-        self.assertTrue(sel.is_selected("cpu"))
-        self.assertTrue(sel.is_selected("Course-LLM"))
-
-    def test_none_selects_no_keys(self) -> None:
-        sel = CourseSelection(picks=[NONE_SENTINEL])
-        self.assertEqual(sel.effective_keys(), [])
-        self.assertFalse(sel.is_selected("cpu"))
-
-    def test_explicit_picks_preserves_order(self) -> None:
-        sel = CourseSelection(picks=["Course-LLM", "cpu"])
-        self.assertEqual(sel.effective_keys(), ["Course-LLM", "cpu"])
-
-    def test_gpu_image_basenames_only_returns_gpu_required(self) -> None:
-        sel = CourseSelection(picks=["cpu", "gpu", "code-gpu", "Course-CV"])
-        # cpu/code-cpu are plain-tagged; gpu/code-gpu/Course-CV are GPU-tagged
-        self.assertEqual(
-            sel.gpu_image_basenames(),
-            ["auplc-base", "auplc-code-gpu", "auplc-cv"],
-        )
-        self.assertEqual(sel.plain_image_basenames(), ["auplc-default"])
-
-    def test_make_targets_includes_every_selected_course(self) -> None:
-        sel = CourseSelection(picks=["cpu", "code-cpu", "Course-DL"])
-        self.assertEqual(sel.make_targets(), ["base-cpu", "code-cpu", "dl"])
-
-    def test_description_default(self) -> None:
-        self.assertEqual(CourseSelection.default().description(), "all (default)")
-
-    def test_description_none(self) -> None:
-        self.assertEqual(CourseSelection(picks=[NONE_SENTINEL]).description(), "none")
-
-    def test_description_custom(self) -> None:
-        sel = CourseSelection(picks=["cpu", "Course-CV"])
-        self.assertEqual(sel.description(), "cpu, Course-CV")
+def test_all_keyword_picks_every_course() -> None:
+    sel = parse_selection_spec("all")
+    assert sel.picks == list(COURSE_PRESET_ALL)
+    assert not sel.is_default()  # explicit selection, not the default sentinel
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_basic_keyword_picks_cpu_gpu_and_code_server() -> None:
+    assert parse_selection_spec("basic").picks == list(COURSE_PRESET_BASIC)
+
+
+def test_none_keyword_uses_sentinel() -> None:
+    sel = parse_selection_spec("none")
+    assert sel.is_none()
+    assert sel.picks == [NONE_SENTINEL]
+
+
+@pytest.mark.parametrize("spec", ["ALL", "All", "Basic", "NONE"])
+def test_keyword_is_case_insensitive(spec: str) -> None:
+    parse_selection_spec(spec)
+
+
+def test_explicit_keys_round_trip() -> None:
+    sel = parse_selection_spec("cpu,gpu,Course-CV")
+    assert sel.picks == ["cpu", "gpu", "Course-CV"]
+
+
+def test_tolerates_whitespace_and_blank_entries() -> None:
+    sel = parse_selection_spec("  cpu , ,Course-CV ")
+    assert sel.picks == ["cpu", "Course-CV"]
+
+
+def test_unknown_key_raises() -> None:
+    with pytest.raises(InstallerError):
+        parse_selection_spec("not-a-real-course")
+
+
+def test_unknown_key_message_lists_valid_keys() -> None:
+    with pytest.raises(InstallerError) as exc_info:
+        parse_selection_spec("nope")
+    msg = str(exc_info.value)
+    assert "nope" in msg
+    for key in COURSE_KEYS_ALL:
+        assert key in msg
+
+
+def test_default_returns_all_keys() -> None:
+    sel = CourseSelection.default()
+    assert sel.effective_keys() == list(COURSE_KEYS_ALL)
+    assert sel.is_selected("cpu")
+    assert sel.is_selected("Course-LLM")
+
+
+def test_none_selects_no_keys() -> None:
+    sel = CourseSelection(picks=[NONE_SENTINEL])
+    assert sel.effective_keys() == []
+    assert not sel.is_selected("cpu")
+
+
+def test_explicit_picks_preserves_order() -> None:
+    sel = CourseSelection(picks=["Course-LLM", "cpu"])
+    assert sel.effective_keys() == ["Course-LLM", "cpu"]
+
+
+def test_gpu_image_basenames_only_returns_gpu_required() -> None:
+    sel = CourseSelection(picks=["cpu", "gpu", "code-gpu", "Course-CV"])
+    # cpu/code-cpu are plain-tagged; gpu/code-gpu/Course-CV are GPU-tagged
+    assert sel.gpu_image_basenames() == [
+        "auplc-base",
+        "auplc-code-gpu",
+        "auplc-cv",
+    ]
+    assert sel.plain_image_basenames() == ["auplc-default"]
+
+
+def test_make_targets_includes_every_selected_course() -> None:
+    sel = CourseSelection(picks=["cpu", "code-cpu", "Course-DL"])
+    assert sel.make_targets() == ["base-cpu", "code-cpu", "dl"]
+
+
+def test_description_default() -> None:
+    assert CourseSelection.default().description() == "all (default)"
+
+
+def test_description_none() -> None:
+    assert CourseSelection(picks=[NONE_SENTINEL]).description() == "none"
+
+
+def test_description_custom() -> None:
+    sel = CourseSelection(picks=["cpu", "Course-CV"])
+    assert sel.description() == "cpu, Course-CV"

--- a/tests/installer/test_cli_helpers.py
+++ b/tests/installer/test_cli_helpers.py
@@ -13,7 +13,6 @@ was passed.
 from __future__ import annotations
 
 import tempfile
-import unittest
 from pathlib import Path
 
 from auplc_installer.catalog import (
@@ -46,45 +45,43 @@ def _write_overlay(path: Path, courses: CourseSelection) -> None:
     )
 
 
-class PreserveCoursesForUpgradeTests(unittest.TestCase):
-    def test_default_courses_inherits_previous_basic(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            overlay = Path(tmp) / "values.local.yaml"
-            _write_overlay(overlay, CourseSelection(picks=list(COURSE_PRESET_BASIC)))
+def test_default_courses_inherits_previous_basic() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        overlay = Path(tmp) / "values.local.yaml"
+        _write_overlay(overlay, CourseSelection(picks=list(COURSE_PRESET_BASIC)))
 
-            state = _make_state_with_courses(CourseSelection.default())
-            _preserve_courses_for_upgrade(state, overlay)
-            self.assertEqual(state.courses.picks, list(COURSE_PRESET_BASIC))
-
-    def test_default_courses_inherits_previous_none_sentinel(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            overlay = Path(tmp) / "values.local.yaml"
-            _write_overlay(overlay, CourseSelection(picks=[NONE_SENTINEL]))
-
-            state = _make_state_with_courses(CourseSelection.default())
-            _preserve_courses_for_upgrade(state, overlay)
-            self.assertTrue(state.courses.is_none())
-
-    def test_explicit_selection_is_not_overwritten(self) -> None:
-        """User-passed --courses=basic must beat whatever the file says."""
-        with tempfile.TemporaryDirectory() as tmp:
-            overlay = Path(tmp) / "values.local.yaml"
-            _write_overlay(overlay, CourseSelection(picks=["cpu"]))
-
-            explicit = CourseSelection(picks=list(COURSE_PRESET_BASIC))
-            state = _make_state_with_courses(explicit)
-            _preserve_courses_for_upgrade(state, overlay)
-            self.assertEqual(state.courses.picks, list(COURSE_PRESET_BASIC))
-
-    def test_missing_overlay_keeps_default(self) -> None:
-        """No prior overlay => upgrade falls back to the historical 'all' default."""
-        with tempfile.TemporaryDirectory() as tmp:
-            overlay = Path(tmp) / "values.local.yaml"  # never created
-
-            state = _make_state_with_courses(CourseSelection.default())
-            _preserve_courses_for_upgrade(state, overlay)
-            self.assertTrue(state.courses.is_default())
+        state = _make_state_with_courses(CourseSelection.default())
+        _preserve_courses_for_upgrade(state, overlay)
+        assert state.courses.picks == list(COURSE_PRESET_BASIC)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_default_courses_inherits_previous_none_sentinel() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        overlay = Path(tmp) / "values.local.yaml"
+        _write_overlay(overlay, CourseSelection(picks=[NONE_SENTINEL]))
+
+        state = _make_state_with_courses(CourseSelection.default())
+        _preserve_courses_for_upgrade(state, overlay)
+        assert state.courses.is_none()
+
+
+def test_explicit_selection_is_not_overwritten() -> None:
+    """User-passed --courses=basic must beat whatever the file says."""
+    with tempfile.TemporaryDirectory() as tmp:
+        overlay = Path(tmp) / "values.local.yaml"
+        _write_overlay(overlay, CourseSelection(picks=["cpu"]))
+
+        explicit = CourseSelection(picks=list(COURSE_PRESET_BASIC))
+        state = _make_state_with_courses(explicit)
+        _preserve_courses_for_upgrade(state, overlay)
+        assert state.courses.picks == list(COURSE_PRESET_BASIC)
+
+
+def test_missing_overlay_keeps_default() -> None:
+    """No prior overlay => upgrade falls back to the historical 'all' default."""
+    with tempfile.TemporaryDirectory() as tmp:
+        overlay = Path(tmp) / "values.local.yaml"  # never created
+
+        state = _make_state_with_courses(CourseSelection.default())
+        _preserve_courses_for_upgrade(state, overlay)
+        assert state.courses.is_default()

--- a/tests/installer/test_cli_install_options.py
+++ b/tests/installer/test_cli_install_options.py
@@ -6,10 +6,11 @@
 from __future__ import annotations
 
 import io
-import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from auplc_installer.catalog import COURSE_PRESET_ALL, CourseSelection
 from auplc_installer.cli import _apply_global_flags, _build_parser, cmd_install_plan, main
@@ -24,175 +25,182 @@ from auplc_installer.summary import (
 from auplc_installer.util import InstallerError
 
 
-class NormalizeImageSourceTests(unittest.TestCase):
-    def test_pull_and_ghcr_alias(self) -> None:
-        self.assertEqual(normalize_image_source("pull"), IMAGE_SOURCE_PULL)
-        self.assertEqual(normalize_image_source("ghcr"), IMAGE_SOURCE_PULL)
-
-    def test_build(self) -> None:
-        self.assertEqual(normalize_image_source("build"), IMAGE_SOURCE_BUILD)
-
-    def test_unknown_raises(self) -> None:
-        with self.assertRaises(InstallerError):
-            normalize_image_source("nope")
+def test_normalize_image_source_pull_and_ghcr_alias() -> None:
+    assert normalize_image_source("pull") == IMAGE_SOURCE_PULL
+    assert normalize_image_source("ghcr") == IMAGE_SOURCE_PULL
 
 
-class ResolveInstallImageSourceTests(unittest.TestCase):
-    def test_default_is_pull(self) -> None:
-        pull, label = resolve_install_image_source(image_source=None, legacy_pull=False)
-        self.assertTrue(pull)
-        self.assertEqual(label, IMAGE_SOURCE_PULL)
-
-    def test_legacy_pull_flag(self) -> None:
-        pull, label = resolve_install_image_source(image_source=None, legacy_pull=True)
-        self.assertTrue(pull)
-        self.assertEqual(label, IMAGE_SOURCE_PULL)
-
-    def test_explicit_pull(self) -> None:
-        pull, label = resolve_install_image_source(image_source="pull", legacy_pull=False)
-        self.assertTrue(pull)
-        self.assertEqual(label, IMAGE_SOURCE_PULL)
-
-    def test_explicit_ghcr_alias(self) -> None:
-        pull, label = resolve_install_image_source(image_source="ghcr", legacy_pull=False)
-        self.assertTrue(pull)
-        self.assertEqual(label, IMAGE_SOURCE_PULL)
-
-    def test_explicit_build(self) -> None:
-        pull, label = resolve_install_image_source(image_source="build", legacy_pull=True)
-        self.assertFalse(pull)
-        self.assertEqual(label, IMAGE_SOURCE_BUILD)
-
-    def test_explicit_build_overrides_legacy_pull(self) -> None:
-        pull, label = resolve_install_image_source(image_source="build", legacy_pull=True)
-        self.assertFalse(pull)
-        self.assertEqual(label, IMAGE_SOURCE_BUILD)
-
-    def test_offline_bundle(self) -> None:
-        pull, label = resolve_install_image_source(
-            image_source="pull",
-            legacy_pull=False,
-            offline_mode=True,
-            bundle_dir=Path("/tmp/bundle"),
-        )
-        self.assertFalse(pull)
-        self.assertIn("Offline bundle", label)
-
-    def test_unknown_source_raises(self) -> None:
-        with self.assertRaises(InstallerError):
-            resolve_install_image_source(image_source="nope", legacy_pull=False)
+def test_normalize_image_source_build() -> None:
+    assert normalize_image_source("build") == IMAGE_SOURCE_BUILD
 
 
-class FormatConfigurationSummaryTests(unittest.TestCase):
-    def test_includes_core_fields(self) -> None:
-        state = InstallerState(
-            gpu_type="strix-halo",
-            use_docker=True,
-            image_registry="ghcr.io/example",
-            image_tag="develop",
-            courses=CourseSelection(picks=list(COURSE_PRESET_ALL)),
-        )
-        text = format_configuration_summary(state, image_source_label=IMAGE_SOURCE_PULL)
-        self.assertIn("Configuration summary", text)
-        self.assertIn("strix-halo", text)
-        self.assertIn("Docker", text)
-        self.assertIn("  Image source     : pull", text)
-        self.assertIn("ghcr.io/example", text)
-        self.assertIn("develop", text)
-        self.assertIn("Course-CV", text)
+def test_normalize_image_source_unknown_raises() -> None:
+    with pytest.raises(InstallerError):
+        normalize_image_source("nope")
 
 
-class ApplyGlobalFlagsTests(unittest.TestCase):
-    def test_gpu_auto_clears_override(self) -> None:
-        state = InstallerState(gpu_type="strix")
-        parser = _build_parser()
-        args = parser.parse_args(["--gpu=auto"])
-        _apply_global_flags(state, args)
-        self.assertEqual(state.gpu_type, "")
-
-    def test_runtime_containerd(self) -> None:
-        state = InstallerState(use_docker=True)
-        parser = _build_parser()
-        args = parser.parse_args(["--runtime=containerd"])
-        _apply_global_flags(state, args)
-        self.assertFalse(state.use_docker)
-
-    def test_runtime_wins_over_docker_flag(self) -> None:
-        state = InstallerState(use_docker=True)
-        parser = _build_parser()
-        args = parser.parse_args(["--runtime=containerd", "--docker=1"])
-        _apply_global_flags(state, args)
-        self.assertFalse(state.use_docker)
-
-    def test_image_flags(self) -> None:
-        state = InstallerState()
-        parser = _build_parser()
-        args = parser.parse_args(
-            [
-                "--image-source=pull",
-                "--image-registry=registry.example.com/org",
-                "--image-tag=develop",
-            ]
-        )
-        _apply_global_flags(state, args)
-        self.assertEqual(state.image_source, "pull")
-        self.assertEqual(state.image_registry, "registry.example.com/org")
-        self.assertEqual(state.image_tag, "develop")
+def test_resolve_install_image_source_default_is_pull() -> None:
+    pull, label = resolve_install_image_source(image_source=None, legacy_pull=False)
+    assert pull
+    assert label == IMAGE_SOURCE_PULL
 
 
-class InstallDryRunTests(unittest.TestCase):
-    def test_install_dry_run_prints_summary(self) -> None:
-        state = InstallerState(
-            image_source="pull",
-            image_tag="develop",
-            courses=CourseSelection(picks=list(COURSE_PRESET_ALL)),
-        )
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            cmd_install_plan(state, legacy_pull=False)
-        out = buf.getvalue()
-        self.assertIn("Configuration summary", out)
-        self.assertIn("develop", out)
-        self.assertIn("  Image source     : pull", out)
-
-    def test_install_dry_run_defaults_to_pull(self) -> None:
-        state = InstallerState()
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            cmd_install_plan(state, legacy_pull=False)
-        out = buf.getvalue()
-        self.assertIn("  Image source     : pull", out)
-
-    def test_help_flag_prints_usage(self) -> None:
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            main(["--help"])
-        out = buf.getvalue()
-        self.assertIn("Usage: ./auplc-installer", out)
-        self.assertIn("install --dry-run", out)
-
-    @patch("auplc_installer.cli._resolve_source_root")
-    @patch("auplc_installer.cli.InstallerState.from_environment")
-    def test_main_install_dry_run(self, mock_from_env, mock_root) -> None:
-        mock_root.return_value = Path("/repo")
-        mock_from_env.return_value = InstallerState(image_tag="develop")
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            main(["install", "--dry-run", "--image-tag=develop"])
-        out = buf.getvalue()
-        self.assertIn("Configuration summary", out)
-        self.assertIn("develop", out)
-        self.assertIn("  Image source     : pull", out)
-
-    @patch("auplc_installer.cli._resolve_source_root")
-    @patch("auplc_installer.cli.InstallerState.from_environment")
-    def test_dry_run_without_install_errors(self, mock_from_env, mock_root) -> None:
-        mock_root.return_value = Path("/repo")
-        mock_from_env.return_value = InstallerState()
-        with self.assertRaises(SystemExit) as ctx:
-            main(["detect-gpu", "--dry-run"])
-        self.assertEqual(ctx.exception.code, 1)
+def test_resolve_install_image_source_legacy_pull_flag() -> None:
+    pull, label = resolve_install_image_source(image_source=None, legacy_pull=True)
+    assert pull
+    assert label == IMAGE_SOURCE_PULL
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_resolve_install_image_source_explicit_pull() -> None:
+    pull, label = resolve_install_image_source(image_source="pull", legacy_pull=False)
+    assert pull
+    assert label == IMAGE_SOURCE_PULL
+
+
+def test_resolve_install_image_source_explicit_ghcr_alias() -> None:
+    pull, label = resolve_install_image_source(image_source="ghcr", legacy_pull=False)
+    assert pull
+    assert label == IMAGE_SOURCE_PULL
+
+
+def test_resolve_install_image_source_explicit_build() -> None:
+    pull, label = resolve_install_image_source(image_source="build", legacy_pull=True)
+    assert not pull
+    assert label == IMAGE_SOURCE_BUILD
+
+
+def test_resolve_install_image_source_explicit_build_overrides_legacy_pull() -> None:
+    pull, label = resolve_install_image_source(image_source="build", legacy_pull=True)
+    assert not pull
+    assert label == IMAGE_SOURCE_BUILD
+
+
+def test_resolve_install_image_source_offline_bundle() -> None:
+    pull, label = resolve_install_image_source(
+        image_source="pull",
+        legacy_pull=False,
+        offline_mode=True,
+        bundle_dir=Path("/tmp/bundle"),
+    )
+    assert not pull
+    assert "Offline bundle" in label
+
+
+def test_resolve_install_image_source_unknown_source_raises() -> None:
+    with pytest.raises(InstallerError):
+        resolve_install_image_source(image_source="nope", legacy_pull=False)
+
+
+def test_format_configuration_summary_includes_core_fields() -> None:
+    state = InstallerState(
+        gpu_type="strix-halo",
+        use_docker=True,
+        image_registry="ghcr.io/example",
+        image_tag="develop",
+        courses=CourseSelection(picks=list(COURSE_PRESET_ALL)),
+    )
+    text = format_configuration_summary(state, image_source_label=IMAGE_SOURCE_PULL)
+    assert "Configuration summary" in text
+    assert "strix-halo" in text
+    assert "Docker" in text
+    assert "  Image source     : pull" in text
+    assert "ghcr.io/example" in text
+    assert "develop" in text
+    assert "Course-CV" in text
+
+
+def test_apply_global_flags_gpu_auto_clears_override() -> None:
+    state = InstallerState(gpu_type="strix")
+    parser = _build_parser()
+    args = parser.parse_args(["--gpu=auto"])
+    _apply_global_flags(state, args)
+    assert state.gpu_type == ""
+
+
+def test_apply_global_flags_runtime_containerd() -> None:
+    state = InstallerState(use_docker=True)
+    parser = _build_parser()
+    args = parser.parse_args(["--runtime=containerd"])
+    _apply_global_flags(state, args)
+    assert not state.use_docker
+
+
+def test_apply_global_flags_runtime_wins_over_docker_flag() -> None:
+    state = InstallerState(use_docker=True)
+    parser = _build_parser()
+    args = parser.parse_args(["--runtime=containerd", "--docker=1"])
+    _apply_global_flags(state, args)
+    assert not state.use_docker
+
+
+def test_apply_global_flags_image_flags() -> None:
+    state = InstallerState()
+    parser = _build_parser()
+    args = parser.parse_args(
+        [
+            "--image-source=pull",
+            "--image-registry=registry.example.com/org",
+            "--image-tag=develop",
+        ]
+    )
+    _apply_global_flags(state, args)
+    assert state.image_source == "pull"
+    assert state.image_registry == "registry.example.com/org"
+    assert state.image_tag == "develop"
+
+
+def test_install_dry_run_prints_summary() -> None:
+    state = InstallerState(
+        image_source="pull",
+        image_tag="develop",
+        courses=CourseSelection(picks=list(COURSE_PRESET_ALL)),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        cmd_install_plan(state, legacy_pull=False)
+    out = buf.getvalue()
+    assert "Configuration summary" in out
+    assert "develop" in out
+    assert "  Image source     : pull" in out
+
+
+def test_install_dry_run_defaults_to_pull() -> None:
+    state = InstallerState()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        cmd_install_plan(state, legacy_pull=False)
+    out = buf.getvalue()
+    assert "  Image source     : pull" in out
+
+
+def test_help_flag_prints_usage() -> None:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        main(["--help"])
+    out = buf.getvalue()
+    assert "Usage: ./auplc-installer" in out
+    assert "install --dry-run" in out
+
+
+@patch("auplc_installer.cli._resolve_source_root")
+@patch("auplc_installer.cli.InstallerState.from_environment")
+def test_main_install_dry_run(mock_from_env, mock_root) -> None:
+    mock_root.return_value = Path("/repo")
+    mock_from_env.return_value = InstallerState(image_tag="develop")
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        main(["install", "--dry-run", "--image-tag=develop"])
+    out = buf.getvalue()
+    assert "Configuration summary" in out
+    assert "develop" in out
+    assert "  Image source     : pull" in out
+
+
+@patch("auplc_installer.cli._resolve_source_root")
+@patch("auplc_installer.cli.InstallerState.from_environment")
+def test_dry_run_without_install_errors(mock_from_env, mock_root) -> None:
+    mock_root.return_value = Path("/repo")
+    mock_from_env.return_value = InstallerState()
+    with pytest.raises(SystemExit) as exc_info:
+        main(["detect-gpu", "--dry-run"])
+    assert exc_info.value.code == 1

--- a/tests/installer/test_gpu.py
+++ b/tests/installer/test_gpu.py
@@ -10,9 +10,10 @@ the installer reads from.
 
 from __future__ import annotations
 
-import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
+
+import pytest
 
 from auplc_installer.gpu import (
     _GFX_FALLBACK,
@@ -35,31 +36,6 @@ from auplc_installer.gpu import (
 )
 from auplc_installer.util import InstallerError
 
-
-class NormaliseProductNameTests(unittest.TestCase):
-    def test_collapses_internal_whitespace(self) -> None:
-        self.assertEqual(normalise_product_name("AMD Radeon  890M Graphics"), "AMD_Radeon_890M_Graphics")
-
-    def test_strips_special_chars_keeping_dot_dash_underscore(self) -> None:
-        # Whitespace becomes "_" first, then non-[A-Za-z0-9._-] chars are
-        # dropped — so the space between "Foo" and "(Bar)" survives as "_".
-        self.assertEqual(normalise_product_name("Foo (Bar)/Baz!"), "Foo_BarBaz")
-        self.assertEqual(normalise_product_name("v1.2-rc3"), "v1.2-rc3")
-
-    def test_strips_outer_underscores(self) -> None:
-        self.assertEqual(normalise_product_name("  Foo Bar  "), "Foo_Bar")
-
-    def test_empty_input_yields_empty(self) -> None:
-        self.assertEqual(normalise_product_name(""), "")
-        self.assertEqual(normalise_product_name("   "), "")
-
-    def test_normalises_ryzen_ai_890m_marketing_name(self) -> None:
-        self.assertEqual(
-            normalise_product_name("AMD Ryzen AI 9 HX 370 w/ Radeon 890M"),
-            "AMD_Ryzen_AI_9_HX_370_w_Radeon_890M",
-        )
-
-
 ROCMINFO_WITH_STRIX_CPU_AND_GPU = """
 Agent 1
 Name:                    AMD Ryzen AI 9 HX 370 w/ Radeon 890M
@@ -77,188 +53,211 @@ ISA 2
 Name:                    amdgcn-amd-amdhsa--gfx11-generic
 """
 
-
-class RocminfoGpuAgentParserTests(unittest.TestCase):
-    def test_records_ignore_cpu_marketing_name_and_keep_gpu_gfx_target(self) -> None:
-        self.assertEqual(
-            _rocminfo_gpu_agent_records(ROCMINFO_WITH_STRIX_CPU_AND_GPU), [("AMD Radeon Graphics", ["gfx1150"])]
-        )
-
-    @patch("auplc_installer.gpu.command_exists", return_value=True)
-    @patch("auplc_installer.gpu.run_capture", return_value=SimpleNamespace(stdout=ROCMINFO_WITH_STRIX_CPU_AND_GPU))
-    def test_detect_gpu_product_names_reads_gpu_agent_marketing_only(self, *_: object) -> None:
-        self.assertEqual(detect_gpu_product_names(), ["AMD_Radeon_Graphics"])
-
-    @patch("auplc_installer.gpu.command_exists", return_value=True)
-    @patch("auplc_installer.gpu.run_capture", return_value=SimpleNamespace(stdout=ROCMINFO_WITH_STRIX_CPU_AND_GPU))
-    def test_detect_gpu_gfx_family_prefers_gpu_agent_target(self, *_: object) -> None:
-        self.assertEqual(detect_gpu_gfx_family(), "gfx1150")
+_PRODUCT_FOR_KEY = {
+    "phx": "AMD_Radeon_780M_Graphics",
+    "strix": "AMD_Radeon_890M_Graphics",
+    "strix-halo": "AMD_Radeon_8060S_Graphics",
+    "9070xt": "AMD_Radeon_RX_9070_XT",
+    "r9700": "AMD_Radeon_AI_PRO_R9700",
+    "9600gre": "AMD_Radeon_RX_9600_GRE",
+}
 
 
-class CuratedSkuLookupTests(unittest.TestCase):
-    def test_known_product_name_resolves_to_curated_row(self) -> None:
-        row = sku_for_product_name("AMD_Radeon_8060S_Graphics")
-        self.assertEqual(row[0], "strix-halo")
-        self.assertEqual(row[1], "gfx1151")
-
-    def test_unknown_product_name_synthesises_row(self) -> None:
-        row = sku_for_product_name("AMD_Mystery_GPU")
-        # Default fallback: gfx120x, no HSA env, quotaRate 4
-        self.assertEqual(row[1], "gfx120x")
-        self.assertEqual(row[2], "")
-        self.assertEqual(row[3], 4)
-        # Synthesised key sanitised to a valid kebab-cased token
-        self.assertEqual(row[0], "amd-mystery-gpu")
-        self.assertEqual(row[4], "AMD Mystery GPU")
-
-    def test_is_curated_sku(self) -> None:
-        for key in GPU_CURATED_SKU_KEYS:
-            with self.subTest(key=key):
-                self.assertTrue(is_curated_sku(key))
-        self.assertFalse(is_curated_sku("9600gre"))
+def _sku_entry(key: str, target: str = "gfx1151") -> SkuEntry:
+    return SkuEntry(
+        accel_key=key,
+        product_name="",
+        gpu_target=target,
+        accel_env="",
+        quota_rate=4,
+        display_name="",
+    )
 
 
-class ResolveGpuConfigTests(unittest.TestCase):
-    def test_known_short_name(self) -> None:
-        accel_key, gpu_target, env, _, _ = resolve_gpu_config("strix-halo")
-        self.assertEqual((accel_key, gpu_target, env), ("strix-halo", "gfx1151", ""))
-
-    def test_known_gfx_alias(self) -> None:
-        accel_key, gpu_target, _, _, _ = resolve_gpu_config("gfx1151")
-        self.assertEqual((accel_key, gpu_target), ("strix-halo", "gfx1151"))
-
-    def test_hyphenated_gfx_alias(self) -> None:
-        accel_key, gpu_target, _, _, _ = resolve_gpu_config("gfx-1150")
-        self.assertEqual((accel_key, gpu_target), ("strix", "gfx1150"))
-
-    def test_normalise_gpu_type_key(self) -> None:
-        self.assertEqual(normalise_gpu_type_key(" GFX-1150 "), "gfx1150")
-        self.assertEqual(normalise_gpu_type_key("strix_halo"), "strix-halo")
-
-    def test_unsupported_input_raises(self) -> None:
-        with self.assertRaises(InstallerError):
-            resolve_gpu_config("totally-not-a-gpu")
+def test_normalise_product_name_collapses_internal_whitespace() -> None:
+    assert normalise_product_name("AMD Radeon  890M Graphics") == "AMD_Radeon_890M_Graphics"
 
 
-class DetectedProductFallbackTests(unittest.TestCase):
-    def test_unknown_product_uses_detected_gfx_family_before_generic_fallback(self) -> None:
-        row = sku_for_detected_product("AMD_Radeon_Graphics", "gfx1150")
-        self.assertEqual(row[0], "strix")
-        self.assertEqual(row[1], "gfx1150")
-
-    def test_unknown_product_without_gfx_family_keeps_generic_fallback(self) -> None:
-        row = sku_for_detected_product("AMD_Radeon_Graphics")
-        self.assertEqual(row[1], "gfx120x")
-
-    @patch("auplc_installer.gpu.detect_gpu_gfx_family", return_value="gfx1150")
-    @patch("auplc_installer.gpu.detect_gpu_product_names", return_value=["AMD_Radeon_Graphics"])
-    def test_detect_and_configure_uses_gfx_for_generic_single_product_name(self, *_: object) -> None:
-        cfg = GpuConfig()
-        detect_and_configure_gpu(cfg)
-        self.assertEqual(cfg.accel_key, "strix")
-        self.assertEqual(cfg.gpu_target, "gfx1150")
-        self.assertEqual(cfg.gpu_product_name, "AMD_Radeon_Graphics")
-
-    @patch("auplc_installer.gpu._read_gpu_product_names_from_node_labels", return_value=["AMD_Radeon_Graphics"])
-    def test_refinement_preserves_existing_gfx_for_generic_product_name(self, *_: object) -> None:
-        cfg = GpuConfig()
-        cfg.append(
-            SkuEntry(
-                accel_key="strix",
-                product_name="AMD_Radeon_Graphics",
-                gpu_target="gfx1150",
-                accel_env="",
-                quota_rate=2,
-                display_name="",
-            )
-        )
-        refine_gpu_config_from_node_labels(cfg)
-        self.assertEqual(cfg.accel_key, "strix")
-        self.assertEqual(cfg.gpu_target, "gfx1150")
+def test_normalise_product_name_strips_special_chars_keeping_dot_dash_underscore() -> None:
+    # Whitespace becomes "_" first, then non-[A-Za-z0-9._-] chars are
+    # dropped — so the space between "Foo" and "(Bar)" survives as "_".
+    assert normalise_product_name("Foo (Bar)/Baz!") == "Foo_BarBaz"
+    assert normalise_product_name("v1.2-rc3") == "v1.2-rc3"
 
 
-class FallbackQuotaRateAlignmentTests(unittest.TestCase):
-    """Regression guard against the Tier-1 bug we just fixed.
-
-    Same physical GPU should map to the same quotaRate whether the user
-    landed on the curated path (PRODUCT_NAME_TO_SKU) or the gfx-family
-    fallback (_GFX_FALLBACK).
-    """
-
-    PRODUCT_FOR_KEY = {
-        "phx": "AMD_Radeon_780M_Graphics",
-        "strix": "AMD_Radeon_890M_Graphics",
-        "strix-halo": "AMD_Radeon_8060S_Graphics",
-        "9070xt": "AMD_Radeon_RX_9070_XT",
-        "r9700": "AMD_Radeon_AI_PRO_R9700",
-        "9600gre": "AMD_Radeon_RX_9600_GRE",
-    }
-
-    def test_fallback_quota_rate_matches_curated(self) -> None:
-        for short_key, product_name in self.PRODUCT_FOR_KEY.items():
-            with self.subTest(key=short_key):
-                fallback_rate = _GFX_FALLBACK[short_key][3]
-                curated_rate = PRODUCT_NAME_TO_SKU[product_name][3]
-                self.assertEqual(
-                    fallback_rate,
-                    curated_rate,
-                    f"_GFX_FALLBACK[{short_key!r}] quota_rate diverges from PRODUCT_NAME_TO_SKU[{product_name!r}]",
-                )
+def test_normalise_product_name_strips_outer_underscores() -> None:
+    assert normalise_product_name("  Foo Bar  ") == "Foo_Bar"
 
 
-class GpuConfigTests(unittest.TestCase):
-    def _entry(self, key: str, target: str = "gfx1151") -> SkuEntry:
-        return SkuEntry(
-            accel_key=key,
-            product_name="",
-            gpu_target=target,
+def test_normalise_product_name_empty_input_yields_empty() -> None:
+    assert normalise_product_name("") == ""
+    assert normalise_product_name("   ") == ""
+
+
+def test_normalise_product_name_normalises_ryzen_ai_890m_marketing_name() -> None:
+    assert normalise_product_name("AMD Ryzen AI 9 HX 370 w/ Radeon 890M") == "AMD_Ryzen_AI_9_HX_370_w_Radeon_890M"
+
+
+def test_rocminfo_records_ignore_cpu_marketing_name_and_keep_gpu_gfx_target() -> None:
+    assert _rocminfo_gpu_agent_records(ROCMINFO_WITH_STRIX_CPU_AND_GPU) == [("AMD Radeon Graphics", ["gfx1150"])]
+
+
+@patch("auplc_installer.gpu.command_exists", return_value=True)
+@patch("auplc_installer.gpu.run_capture", return_value=SimpleNamespace(stdout=ROCMINFO_WITH_STRIX_CPU_AND_GPU))
+def test_detect_gpu_product_names_reads_gpu_agent_marketing_only(*_: object) -> None:
+    assert detect_gpu_product_names() == ["AMD_Radeon_Graphics"]
+
+
+@patch("auplc_installer.gpu.command_exists", return_value=True)
+@patch("auplc_installer.gpu.run_capture", return_value=SimpleNamespace(stdout=ROCMINFO_WITH_STRIX_CPU_AND_GPU))
+def test_detect_gpu_gfx_family_prefers_gpu_agent_target(*_: object) -> None:
+    assert detect_gpu_gfx_family() == "gfx1150"
+
+
+def test_known_product_name_resolves_to_curated_row() -> None:
+    row = sku_for_product_name("AMD_Radeon_8060S_Graphics")
+    assert row[0] == "strix-halo"
+    assert row[1] == "gfx1151"
+
+
+def test_unknown_product_name_synthesises_row() -> None:
+    row = sku_for_product_name("AMD_Mystery_GPU")
+    # Default fallback: gfx120x, no HSA env, quotaRate 4
+    assert row[1] == "gfx120x"
+    assert row[2] == ""
+    assert row[3] == 4
+    # Synthesised key sanitised to a valid kebab-cased token
+    assert row[0] == "amd-mystery-gpu"
+    assert row[4] == "AMD Mystery GPU"
+
+
+@pytest.mark.parametrize("key", GPU_CURATED_SKU_KEYS)
+def test_is_curated_sku(key: str) -> None:
+    assert is_curated_sku(key)
+
+
+def test_is_curated_sku_false_for_unknown() -> None:
+    assert not is_curated_sku("9600gre")
+
+
+def test_resolve_gpu_config_known_short_name() -> None:
+    accel_key, gpu_target, env, _, _ = resolve_gpu_config("strix-halo")
+    assert (accel_key, gpu_target, env) == ("strix-halo", "gfx1151", "")
+
+
+def test_resolve_gpu_config_known_gfx_alias() -> None:
+    accel_key, gpu_target, _, _, _ = resolve_gpu_config("gfx1151")
+    assert (accel_key, gpu_target) == ("strix-halo", "gfx1151")
+
+
+def test_resolve_gpu_config_hyphenated_gfx_alias() -> None:
+    accel_key, gpu_target, _, _, _ = resolve_gpu_config("gfx-1150")
+    assert (accel_key, gpu_target) == ("strix", "gfx1150")
+
+
+def test_normalise_gpu_type_key() -> None:
+    assert normalise_gpu_type_key(" GFX-1150 ") == "gfx1150"
+    assert normalise_gpu_type_key("strix_halo") == "strix-halo"
+
+
+def test_resolve_gpu_config_unsupported_input_raises() -> None:
+    with pytest.raises(InstallerError):
+        resolve_gpu_config("totally-not-a-gpu")
+
+
+def test_unknown_product_uses_detected_gfx_family_before_generic_fallback() -> None:
+    row = sku_for_detected_product("AMD_Radeon_Graphics", "gfx1150")
+    assert row[0] == "strix"
+    assert row[1] == "gfx1150"
+
+
+def test_unknown_product_without_gfx_family_keeps_generic_fallback() -> None:
+    row = sku_for_detected_product("AMD_Radeon_Graphics")
+    assert row[1] == "gfx120x"
+
+
+@patch("auplc_installer.gpu.detect_gpu_gfx_family", return_value="gfx1150")
+@patch("auplc_installer.gpu.detect_gpu_product_names", return_value=["AMD_Radeon_Graphics"])
+def test_detect_and_configure_uses_gfx_for_generic_single_product_name(*_: object) -> None:
+    cfg = GpuConfig()
+    detect_and_configure_gpu(cfg)
+    assert cfg.accel_key == "strix"
+    assert cfg.gpu_target == "gfx1150"
+    assert cfg.gpu_product_name == "AMD_Radeon_Graphics"
+
+
+@patch("auplc_installer.gpu._read_gpu_product_names_from_node_labels", return_value=["AMD_Radeon_Graphics"])
+def test_refinement_preserves_existing_gfx_for_generic_product_name(*_: object) -> None:
+    cfg = GpuConfig()
+    cfg.append(
+        SkuEntry(
+            accel_key="strix",
+            product_name="AMD_Radeon_Graphics",
+            gpu_target="gfx1150",
             accel_env="",
-            quota_rate=4,
+            quota_rate=2,
             display_name="",
         )
-
-    def test_append_dedups_by_accel_key(self) -> None:
-        cfg = GpuConfig()
-        cfg.append(self._entry("strix-halo"))
-        cfg.append(self._entry("strix-halo"))  # duplicate
-        self.assertEqual(len(cfg.skus), 1)
-
-    def test_first_entry_drives_primary_scalars(self) -> None:
-        cfg = GpuConfig()
-        cfg.append(self._entry("strix-halo", target="gfx1151"))
-        cfg.append(self._entry("9070xt", target="gfx1201"))
-        self.assertEqual(cfg.accel_key, "strix-halo")
-        self.assertEqual(cfg.gpu_target, "gfx1151")
-
-    def test_homogeneous_target_true_for_single_sku(self) -> None:
-        cfg = GpuConfig()
-        cfg.append(self._entry("strix-halo"))
-        self.assertTrue(cfg.homogeneous_target)
-
-    def test_homogeneous_target_false_for_mixed_gfx(self) -> None:
-        cfg = GpuConfig()
-        cfg.append(self._entry("strix-halo", target="gfx1151"))
-        cfg.append(self._entry("9070xt", target="gfx1201"))
-        self.assertFalse(cfg.homogeneous_target)
-
-    def test_append_product_uses_curated_table_when_known(self) -> None:
-        cfg = GpuConfig()
-        append_product(cfg, "AMD_Radeon_8060S_Graphics")
-        self.assertEqual(cfg.accel_key, "strix-halo")
-        self.assertEqual(cfg.gpu_target, "gfx1151")
-        self.assertEqual(cfg.skus[0].product_name, "AMD_Radeon_8060S_Graphics")
-
-    def test_append_product_synthesises_row_when_unknown(self) -> None:
-        cfg = GpuConfig()
-        append_product(cfg, "AMD_Some_Future_GPU")
-        self.assertEqual(cfg.accel_key, "amd-some-future-gpu")
-        self.assertEqual(cfg.gpu_target, "gfx120x")
-
-    def test_append_product_ignores_empty_string(self) -> None:
-        cfg = GpuConfig()
-        append_product(cfg, "")
-        self.assertEqual(cfg.skus, [])
+    )
+    refine_gpu_config_from_node_labels(cfg)
+    assert cfg.accel_key == "strix"
+    assert cfg.gpu_target == "gfx1150"
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize("short_key,product_name", list(_PRODUCT_FOR_KEY.items()))
+def test_fallback_quota_rate_matches_curated(short_key: str, product_name: str) -> None:
+    """Same physical GPU should map to the same quotaRate on both paths."""
+    fallback_rate = _GFX_FALLBACK[short_key][3]
+    curated_rate = PRODUCT_NAME_TO_SKU[product_name][3]
+    assert fallback_rate == curated_rate, (
+        f"_GFX_FALLBACK[{short_key!r}] quota_rate diverges from PRODUCT_NAME_TO_SKU[{product_name!r}]"
+    )
+
+
+def test_gpu_config_append_dedups_by_accel_key() -> None:
+    cfg = GpuConfig()
+    cfg.append(_sku_entry("strix-halo"))
+    cfg.append(_sku_entry("strix-halo"))  # duplicate
+    assert len(cfg.skus) == 1
+
+
+def test_gpu_config_first_entry_drives_primary_scalars() -> None:
+    cfg = GpuConfig()
+    cfg.append(_sku_entry("strix-halo", target="gfx1151"))
+    cfg.append(_sku_entry("9070xt", target="gfx1201"))
+    assert cfg.accel_key == "strix-halo"
+    assert cfg.gpu_target == "gfx1151"
+
+
+def test_gpu_config_homogeneous_target_true_for_single_sku() -> None:
+    cfg = GpuConfig()
+    cfg.append(_sku_entry("strix-halo"))
+    assert cfg.homogeneous_target
+
+
+def test_gpu_config_homogeneous_target_false_for_mixed_gfx() -> None:
+    cfg = GpuConfig()
+    cfg.append(_sku_entry("strix-halo", target="gfx1151"))
+    cfg.append(_sku_entry("9070xt", target="gfx1201"))
+    assert not cfg.homogeneous_target
+
+
+def test_append_product_uses_curated_table_when_known() -> None:
+    cfg = GpuConfig()
+    append_product(cfg, "AMD_Radeon_8060S_Graphics")
+    assert cfg.accel_key == "strix-halo"
+    assert cfg.gpu_target == "gfx1151"
+    assert cfg.skus[0].product_name == "AMD_Radeon_8060S_Graphics"
+
+
+def test_append_product_synthesises_row_when_unknown() -> None:
+    cfg = GpuConfig()
+    append_product(cfg, "AMD_Some_Future_GPU")
+    assert cfg.accel_key == "amd-some-future-gpu"
+    assert cfg.gpu_target == "gfx120x"
+
+
+def test_append_product_ignores_empty_string() -> None:
+    cfg = GpuConfig()
+    append_product(cfg, "")
+    assert cfg.skus == []

--- a/tests/installer/test_images.py
+++ b/tests/installer/test_images.py
@@ -12,7 +12,8 @@ exercised here.
 from __future__ import annotations
 
 import re
-import unittest
+
+import pytest
 
 from auplc_installer.images import (
     BUILD_ONLY_IMAGES,
@@ -20,63 +21,43 @@ from auplc_installer.images import (
     resolve_pull_ref,
 )
 
-
-class ResolvePullRefTests(unittest.TestCase):
-    def test_bare_image_gets_docker_io_library_prefix(self) -> None:
-        self.assertEqual(resolve_pull_ref("alpine", mirror_prefix=""), "docker.io/library/alpine")
-
-    def test_user_image_without_dot_in_first_segment_gets_docker_io(self) -> None:
-        self.assertEqual(resolve_pull_ref("foo/bar", mirror_prefix=""), "docker.io/foo/bar")
-
-    def test_explicit_registry_is_preserved(self) -> None:
-        self.assertEqual(
-            resolve_pull_ref("quay.io/jupyterhub/k8s-hub:4.3.3", mirror_prefix=""),
-            "quay.io/jupyterhub/k8s-hub:4.3.3",
-        )
-
-    def test_registry_k8s_io_is_preserved(self) -> None:
-        self.assertEqual(
-            resolve_pull_ref("registry.k8s.io/pause:3.10.1", mirror_prefix=""),
-            "registry.k8s.io/pause:3.10.1",
-        )
-
-    def test_mirror_prefix_prepended_after_registry_resolution(self) -> None:
-        self.assertEqual(
-            resolve_pull_ref("alpine", mirror_prefix="m.example.com"),
-            "m.example.com/docker.io/library/alpine",
-        )
-        self.assertEqual(
-            resolve_pull_ref("foo/bar", mirror_prefix="m.example.com"),
-            "m.example.com/docker.io/foo/bar",
-        )
-        self.assertEqual(
-            resolve_pull_ref("quay.io/jupyterhub/k8s-hub:4.3.3", mirror_prefix="m.example.com"),
-            "m.example.com/quay.io/jupyterhub/k8s-hub:4.3.3",
-        )
+_TAG_RE = re.compile(r":[A-Za-z0-9_.-]+$")
 
 
-class ImageConstantsTests(unittest.TestCase):
-    """Static guarantees about the image lists we ship.
-
-    Tags must be explicit so pre-pulls and Dockerfile FROM lines stay in
-    lock-step (regression guard for the implicit ``:latest`` bug).
-    """
-
-    _TAG_RE = re.compile(r":[A-Za-z0-9_.-]+$")
-
-    def test_every_external_image_has_explicit_tag(self) -> None:
-        for image in EXTERNAL_IMAGES:
-            with self.subTest(image=image):
-                self.assertRegex(image, self._TAG_RE, f"{image!r} is missing an explicit tag")
-
-    def test_every_build_only_image_has_explicit_tag(self) -> None:
-        for image in BUILD_ONLY_IMAGES:
-            with self.subTest(image=image):
-                self.assertRegex(image, self._TAG_RE, f"{image!r} is missing an explicit tag")
-
-    def test_no_duplicate_external_images(self) -> None:
-        self.assertEqual(len(EXTERNAL_IMAGES), len(set(EXTERNAL_IMAGES)))
+def test_bare_image_gets_docker_io_library_prefix() -> None:
+    assert resolve_pull_ref("alpine", mirror_prefix="") == "docker.io/library/alpine"
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_user_image_without_dot_in_first_segment_gets_docker_io() -> None:
+    assert resolve_pull_ref("foo/bar", mirror_prefix="") == "docker.io/foo/bar"
+
+
+def test_explicit_registry_is_preserved() -> None:
+    assert resolve_pull_ref("quay.io/jupyterhub/k8s-hub:4.3.3", mirror_prefix="") == "quay.io/jupyterhub/k8s-hub:4.3.3"
+
+
+def test_registry_k8s_io_is_preserved() -> None:
+    assert resolve_pull_ref("registry.k8s.io/pause:3.10.1", mirror_prefix="") == "registry.k8s.io/pause:3.10.1"
+
+
+def test_mirror_prefix_prepended_after_registry_resolution() -> None:
+    assert resolve_pull_ref("alpine", mirror_prefix="m.example.com") == "m.example.com/docker.io/library/alpine"
+    assert resolve_pull_ref("foo/bar", mirror_prefix="m.example.com") == "m.example.com/docker.io/foo/bar"
+    assert (
+        resolve_pull_ref("quay.io/jupyterhub/k8s-hub:4.3.3", mirror_prefix="m.example.com")
+        == "m.example.com/quay.io/jupyterhub/k8s-hub:4.3.3"
+    )
+
+
+@pytest.mark.parametrize("image", EXTERNAL_IMAGES)
+def test_every_external_image_has_explicit_tag(image: str) -> None:
+    assert _TAG_RE.search(image), f"{image!r} is missing an explicit tag"
+
+
+@pytest.mark.parametrize("image", BUILD_ONLY_IMAGES)
+def test_every_build_only_image_has_explicit_tag(image: str) -> None:
+    assert _TAG_RE.search(image), f"{image!r} is missing an explicit tag"
+
+
+def test_no_duplicate_external_images() -> None:
+    assert len(EXTERNAL_IMAGES) == len(set(EXTERNAL_IMAGES))

--- a/tests/installer/test_manifest.py
+++ b/tests/installer/test_manifest.py
@@ -12,86 +12,83 @@ from __future__ import annotations
 
 import json
 import tempfile
-import unittest
 from pathlib import Path
 
 from auplc_installer.manifest import BundleManifest, detect_offline_bundle
 
 
-class BundleManifestRoundTripTests(unittest.TestCase):
-    def _sample(self) -> BundleManifest:
-        return BundleManifest(
-            format_version="1",
-            build_date="2026-04-29T06:00:00Z",
-            gpu_target="gfx1151",
-            accel_key="strix-halo",
-            accel_env="",
-            image_registry="ghcr.io/amdresearch",
-            image_tag="v1.0",
-            k3s_version="v1.32.3+k3s1",
-            helm_version="v3.17.2",
-            k9s_version="v0.32.7",
+def _sample_manifest() -> BundleManifest:
+    return BundleManifest(
+        format_version="1",
+        build_date="2026-04-29T06:00:00Z",
+        gpu_target="gfx1151",
+        accel_key="strix-halo",
+        accel_env="",
+        image_registry="ghcr.io/amdresearch",
+        image_tag="v1.0",
+        k3s_version="v1.32.3+k3s1",
+        helm_version="v3.17.2",
+        k9s_version="v0.32.7",
+    )
+
+
+def test_write_then_from_path_recovers_every_field() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "manifest.json"
+        original = _sample_manifest()
+        original.write(path)
+        loaded = BundleManifest.from_path(path)
+        assert loaded == original
+
+
+def test_write_emits_4_space_indent() -> None:
+    """Bash version layout is contractual for human-diff readability."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "manifest.json"
+        _sample_manifest().write(path)
+        text = path.read_text(encoding="utf-8")
+        # Every continuation line should start with at least 4 spaces of indent
+        for line in text.splitlines()[1:-1]:
+            if line.strip():
+                assert line.startswith("    "), f"bad indent: {line!r}"
+
+
+def test_write_appends_trailing_newline() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "manifest.json"
+        _sample_manifest().write(path)
+        assert path.read_text(encoding="utf-8").endswith("}\n")
+
+
+def test_from_path_tolerates_missing_optional_fields() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "manifest.json"
+        path.write_text(json.dumps({"format_version": "1"}), encoding="utf-8")
+        m = BundleManifest.from_path(path)
+        assert m.format_version == "1"
+        assert m.gpu_target == ""
+        assert m.image_registry == ""
+
+
+def test_detect_offline_bundle_returns_none_when_manifest_absent() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        assert detect_offline_bundle(tmp) is None
+
+
+def test_detect_offline_bundle_returns_parsed_manifest_when_present() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "format_version": "1",
+                    "gpu_target": "gfx1151",
+                    "image_registry": "ghcr.io/amdresearch",
+                    "image_tag": "v1.0",
+                }
+            ),
+            encoding="utf-8",
         )
-
-    def test_write_then_from_path_recovers_every_field(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "manifest.json"
-            original = self._sample()
-            original.write(path)
-            loaded = BundleManifest.from_path(path)
-            self.assertEqual(loaded, original)
-
-    def test_write_emits_4_space_indent(self) -> None:
-        """Bash version layout is contractual for human-diff readability."""
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "manifest.json"
-            self._sample().write(path)
-            text = path.read_text(encoding="utf-8")
-            # Every continuation line should start with at least 4 spaces of indent
-            for line in text.splitlines()[1:-1]:
-                if line.strip():
-                    self.assertTrue(line.startswith("    "), f"bad indent: {line!r}")
-
-    def test_write_appends_trailing_newline(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "manifest.json"
-            self._sample().write(path)
-            self.assertTrue(path.read_text(encoding="utf-8").endswith("}\n"))
-
-    def test_from_path_tolerates_missing_optional_fields(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "manifest.json"
-            path.write_text(json.dumps({"format_version": "1"}), encoding="utf-8")
-            m = BundleManifest.from_path(path)
-            self.assertEqual(m.format_version, "1")
-            self.assertEqual(m.gpu_target, "")
-            self.assertEqual(m.image_registry, "")
-
-
-class DetectOfflineBundleTests(unittest.TestCase):
-    def test_returns_none_when_manifest_absent(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            self.assertIsNone(detect_offline_bundle(tmp))
-
-    def test_returns_parsed_manifest_when_present(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            (Path(tmp) / "manifest.json").write_text(
-                json.dumps(
-                    {
-                        "format_version": "1",
-                        "gpu_target": "gfx1151",
-                        "image_registry": "ghcr.io/amdresearch",
-                        "image_tag": "v1.0",
-                    }
-                ),
-                encoding="utf-8",
-            )
-            m = detect_offline_bundle(tmp)
-            self.assertIsNotNone(m)
-            assert m is not None  # narrow for type checkers
-            self.assertEqual(m.gpu_target, "gfx1151")
-            self.assertEqual(m.image_tag, "v1.0")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        m = detect_offline_bundle(tmp)
+        assert m is not None
+        assert m.gpu_target == "gfx1151"
+        assert m.image_tag == "v1.0"

--- a/tests/installer/test_overlay.py
+++ b/tests/installer/test_overlay.py
@@ -16,7 +16,6 @@ formatting drift can break ``helm install``. These tests assert two things:
 from __future__ import annotations
 
 import tempfile
-import unittest
 from pathlib import Path
 
 import yaml
@@ -57,262 +56,230 @@ def _render(
     return text, yaml.safe_load(text)
 
 
-class OverlayDefaultSelectionTests(unittest.TestCase):
-    def test_default_selection_round_trips_valid_yaml(self) -> None:
-        text, parsed = _render(_strix_halo_cfg(), courses=CourseSelection.default())
-        self.assertIsInstance(parsed, dict)
-        self.assertIn("custom", parsed)
-        # default selection must NOT emit teams.mapping
-        self.assertNotIn("teams", parsed["custom"])
-
-    def test_resource_images_use_primary_tag(self) -> None:
-        _, parsed = _render(_strix_halo_cfg(), courses=CourseSelection.default())
-        images = parsed["custom"]["resources"]["images"]
-        self.assertEqual(images["gpu"], "ghcr.io/amdresearch/auplc-base:v1.0-gfx1151")
-        self.assertEqual(images["code-gpu"], "ghcr.io/amdresearch/auplc-code-gpu:v1.0-gfx1151")
-        self.assertEqual(images["Course-CV"], "ghcr.io/amdresearch/auplc-cv:v1.0-gfx1151")
-        self.assertEqual(images["Course-PhySim"], "ghcr.io/amdresearch/auplc-physim:v1.0-gfx1151")
-
-    def test_curated_sku_with_product_name_emits_node_selector(self) -> None:
-        _, parsed = _render(_strix_halo_cfg(), courses=CourseSelection.default())
-        accelerators = parsed["custom"]["accelerators"]
-        self.assertIn("strix-halo", accelerators)
-        self.assertEqual(
-            accelerators["strix-halo"]["nodeSelector"]["amd.com/gpu.product-name"],
-            "AMD_Radeon_8060S_Graphics",
+def _mixed_config() -> GpuConfig:
+    cfg = GpuConfig()
+    # primary: strix-halo / gfx1151
+    cfg.append(
+        SkuEntry(
+            accel_key="strix-halo",
+            product_name="AMD_Radeon_8060S_Graphics",
+            gpu_target="gfx1151",
+            accel_env="",
+            quota_rate=3,
+            display_name="",
         )
-
-
-class OverlayBasicSelectionTests(unittest.TestCase):
-    def test_basic_emits_filtered_teams_mapping(self) -> None:
-        _, parsed = _render(
-            _strix_halo_cfg(),
-            courses=CourseSelection(picks=list(COURSE_PRESET_BASIC)),
+    )
+    # secondary: r9700 / gfx120x  (different family → triggers overrides)
+    cfg.append(
+        SkuEntry(
+            accel_key="r9700",
+            product_name="AMD_Radeon_AI_PRO_R9700",
+            gpu_target="gfx120x",
+            accel_env="",
+            quota_rate=4,
+            display_name="",
         )
-        mapping = parsed["custom"]["teams"]["mapping"]
-        self.assertEqual(mapping["cpu"], ["cpu", "code-cpu"])
-        self.assertEqual(mapping["gpu"], ["code-gpu"])
-
-    def test_basic_omits_unselected_resource_images(self) -> None:
-        _, parsed = _render(
-            _strix_halo_cfg(),
-            courses=CourseSelection(picks=list(COURSE_PRESET_BASIC)),
-        )
-        images = parsed["custom"]["resources"]["images"]
-        self.assertIn("gpu", images)
-        self.assertIn("code-gpu", images)
-        self.assertNotIn("Course-CV", images)
-        self.assertNotIn("Course-LLM", images)
+    )
+    return cfg
 
 
-class OverlayNoneSelectionTests(unittest.TestCase):
-    def test_none_results_in_empty_teams_and_no_resources(self) -> None:
-        _, parsed = _render(
-            _strix_halo_cfg(),
-            courses=CourseSelection(picks=[NONE_SENTINEL]),
-        )
-        custom = parsed["custom"]
-        # Every team filtered to empty list since no course is picked
-        for team_courses in custom["teams"]["mapping"].values():
-            self.assertEqual(team_courses, [])
-        # No GPU resources should be emitted
-        self.assertNotIn("resources", custom)
-
-
-class OverlayOfflineModeTests(unittest.TestCase):
-    def test_offline_mode_injects_hub_image_override(self) -> None:
-        _, parsed = _render(
-            _strix_halo_cfg(),
-            courses=CourseSelection.default(),
-            offline_mode=True,
-        )
-        self.assertIn("hub", parsed)
-        self.assertEqual(parsed["hub"]["image"]["name"], "ghcr.io/amdresearch/auplc-hub")
-        self.assertEqual(parsed["hub"]["image"]["tag"], "v1.0")
-        self.assertEqual(parsed["hub"]["image"]["pullPolicy"], "IfNotPresent")
-
-    def test_online_mode_omits_hub_image_override(self) -> None:
-        _, parsed = _render(
-            _strix_halo_cfg(),
-            courses=CourseSelection.default(),
+def _write_and_read_back(courses: CourseSelection) -> CourseSelection | None:
+    cfg = _strix_halo_cfg()
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "values.local.yaml"
+        generate_values_overlay(
+            cfg,
+            image_registry="ghcr.io/amdresearch",
+            image_tag="v1.0",
+            courses=courses,
             offline_mode=False,
+            overlay_path=path,
         )
-        self.assertNotIn("hub", parsed)
+        return try_load_courses_from_overlay(path)
 
 
-class OverlayUncuratedSkuTests(unittest.TestCase):
-    """Synthesised SKU should still produce a complete, helm-mergeable stanza."""
+def test_default_selection_round_trips_valid_yaml() -> None:
+    text, parsed = _render(_strix_halo_cfg(), courses=CourseSelection.default())
+    assert isinstance(parsed, dict)
+    assert "custom" in parsed
+    # default selection must NOT emit teams.mapping
+    assert "teams" not in parsed["custom"]
 
-    def test_uncurated_sku_emits_full_stanza_with_quota(self) -> None:
-        cfg = GpuConfig()
-        append_product(cfg, "AMD_Some_Future_GPU")
-        _, parsed = _render(cfg, courses=CourseSelection.default())
-        accel = parsed["custom"]["accelerators"]["amd-some-future-gpu"]
-        self.assertEqual(accel["quotaRate"], 4)
-        self.assertIn("displayName", accel)
-        self.assertIn("description", accel)
-        self.assertEqual(
-            accel["nodeSelector"]["amd.com/gpu.product-name"],
-            "AMD_Some_Future_GPU",
+
+def test_resource_images_use_primary_tag() -> None:
+    _, parsed = _render(_strix_halo_cfg(), courses=CourseSelection.default())
+    images = parsed["custom"]["resources"]["images"]
+    assert images["gpu"] == "ghcr.io/amdresearch/auplc-base:v1.0-gfx1151"
+    assert images["code-gpu"] == "ghcr.io/amdresearch/auplc-code-gpu:v1.0-gfx1151"
+    assert images["Course-CV"] == "ghcr.io/amdresearch/auplc-cv:v1.0-gfx1151"
+    assert images["Course-PhySim"] == "ghcr.io/amdresearch/auplc-physim:v1.0-gfx1151"
+
+
+def test_curated_sku_with_product_name_emits_node_selector() -> None:
+    _, parsed = _render(_strix_halo_cfg(), courses=CourseSelection.default())
+    accelerators = parsed["custom"]["accelerators"]
+    assert "strix-halo" in accelerators
+    assert accelerators["strix-halo"]["nodeSelector"]["amd.com/gpu.product-name"] == "AMD_Radeon_8060S_Graphics"
+
+
+def test_basic_emits_filtered_teams_mapping() -> None:
+    _, parsed = _render(
+        _strix_halo_cfg(),
+        courses=CourseSelection(picks=list(COURSE_PRESET_BASIC)),
+    )
+    mapping = parsed["custom"]["teams"]["mapping"]
+    assert mapping["cpu"] == ["cpu", "code-cpu"]
+    assert mapping["gpu"] == ["code-gpu"]
+
+
+def test_basic_omits_unselected_resource_images() -> None:
+    _, parsed = _render(
+        _strix_halo_cfg(),
+        courses=CourseSelection(picks=list(COURSE_PRESET_BASIC)),
+    )
+    images = parsed["custom"]["resources"]["images"]
+    assert "gpu" in images
+    assert "code-gpu" in images
+    assert "Course-CV" not in images
+    assert "Course-LLM" not in images
+
+
+def test_none_results_in_empty_teams_and_no_resources() -> None:
+    _, parsed = _render(
+        _strix_halo_cfg(),
+        courses=CourseSelection(picks=[NONE_SENTINEL]),
+    )
+    custom = parsed["custom"]
+    # Every team filtered to empty list since no course is picked
+    for team_courses in custom["teams"]["mapping"].values():
+        assert team_courses == []
+    # No GPU resources should be emitted
+    assert "resources" not in custom
+
+
+def test_offline_mode_injects_hub_image_override() -> None:
+    _, parsed = _render(
+        _strix_halo_cfg(),
+        courses=CourseSelection.default(),
+        offline_mode=True,
+    )
+    assert "hub" in parsed
+    assert parsed["hub"]["image"]["name"] == "ghcr.io/amdresearch/auplc-hub"
+    assert parsed["hub"]["image"]["tag"] == "v1.0"
+    assert parsed["hub"]["image"]["pullPolicy"] == "IfNotPresent"
+
+
+def test_online_mode_omits_hub_image_override() -> None:
+    _, parsed = _render(
+        _strix_halo_cfg(),
+        courses=CourseSelection.default(),
+        offline_mode=False,
+    )
+    assert "hub" not in parsed
+
+
+def test_uncurated_sku_emits_full_stanza_with_quota() -> None:
+    cfg = GpuConfig()
+    append_product(cfg, "AMD_Some_Future_GPU")
+    _, parsed = _render(cfg, courses=CourseSelection.default())
+    accel = parsed["custom"]["accelerators"]["amd-some-future-gpu"]
+    assert accel["quotaRate"] == 4
+    assert "displayName" in accel
+    assert "description" in accel
+    assert accel["nodeSelector"]["amd.com/gpu.product-name"] == "AMD_Some_Future_GPU"
+
+
+def test_mixed_targets_emit_accelerator_overrides() -> None:
+    _, parsed = _render(_mixed_config(), courses=CourseSelection.default())
+    gpu_metadata = parsed["custom"]["resources"]["metadata"]["gpu"]
+    assert "acceleratorOverrides" in gpu_metadata
+    overrides = gpu_metadata["acceleratorOverrides"]
+    assert "r9700" in overrides
+    assert overrides["r9700"]["image"] == "ghcr.io/amdresearch/auplc-base:v1.0-gfx120x"
+
+
+def test_mixed_targets_acceleratorkeys_lists_every_sku() -> None:
+    _, parsed = _render(_mixed_config(), courses=CourseSelection.default())
+    keys = parsed["custom"]["resources"]["metadata"]["gpu"]["acceleratorKeys"]
+    assert set(keys) == {"strix-halo", "r9700"}
+
+
+def test_phx_emits_hsa_override_env() -> None:
+    cfg = GpuConfig()
+    append_product(cfg, "AMD_Radeon_780M_Graphics")  # phx, sets HSA_OVERRIDE
+    _, parsed = _render(cfg, courses=CourseSelection.default())
+    env = parsed["custom"]["accelerators"]["phx"]["env"]
+    assert env["HSA_OVERRIDE_GFX_VERSION"] == "11.0.0"
+
+
+def test_fallback_path_skips_accelerator_stanza_for_curated_sku() -> None:
+    cfg = GpuConfig()
+    cfg.append(
+        SkuEntry(
+            accel_key="strix",
+            product_name="",  # fallback path
+            gpu_target="gfx1150",
+            accel_env="",
+            quota_rate=2,
+            display_name="",
         )
+    )
+    _, parsed = _render(cfg, courses=CourseSelection.default())
+    assert "accelerators" not in parsed["custom"]
 
 
-class OverlayMixedTargetsTests(unittest.TestCase):
-    """When SKUs straddle gfx families we must emit acceleratorOverrides."""
-
-    def _mixed_config(self) -> GpuConfig:
-        cfg = GpuConfig()
-        # primary: strix-halo / gfx1151
-        cfg.append(
-            SkuEntry(
-                accel_key="strix-halo",
-                product_name="AMD_Radeon_8060S_Graphics",
-                gpu_target="gfx1151",
-                accel_env="",
-                quota_rate=3,
-                display_name="",
-            )
-        )
-        # secondary: r9700 / gfx120x  (different family → triggers overrides)
-        cfg.append(
-            SkuEntry(
-                accel_key="r9700",
-                product_name="AMD_Radeon_AI_PRO_R9700",
-                gpu_target="gfx120x",
-                accel_env="",
-                quota_rate=4,
-                display_name="",
-            )
-        )
-        return cfg
-
-    def test_mixed_targets_emit_accelerator_overrides(self) -> None:
-        _, parsed = _render(self._mixed_config(), courses=CourseSelection.default())
-        gpu_metadata = parsed["custom"]["resources"]["metadata"]["gpu"]
-        self.assertIn("acceleratorOverrides", gpu_metadata)
-        overrides = gpu_metadata["acceleratorOverrides"]
-        self.assertIn("r9700", overrides)
-        self.assertEqual(
-            overrides["r9700"]["image"],
-            "ghcr.io/amdresearch/auplc-base:v1.0-gfx120x",
-        )
-
-    def test_mixed_targets_acceleratorkeys_lists_every_sku(self) -> None:
-        _, parsed = _render(self._mixed_config(), courses=CourseSelection.default())
-        keys = parsed["custom"]["resources"]["metadata"]["gpu"]["acceleratorKeys"]
-        self.assertEqual(set(keys), {"strix-halo", "r9700"})
+def test_env_selection_header_round_trips() -> None:
+    loaded = _write_and_read_back(CourseSelection.default())
+    assert loaded is not None
+    assert loaded.is_default()
 
 
-class OverlayHsaOverrideTests(unittest.TestCase):
-    def test_phx_emits_hsa_override_env(self) -> None:
-        cfg = GpuConfig()
-        append_product(cfg, "AMD_Radeon_780M_Graphics")  # phx, sets HSA_OVERRIDE
-        _, parsed = _render(cfg, courses=CourseSelection.default())
-        env = parsed["custom"]["accelerators"]["phx"]["env"]
-        self.assertEqual(env["HSA_OVERRIDE_GFX_VERSION"], "11.0.0")
-
-
-class OverlayFallbackPathTests(unittest.TestCase):
-    """Curated key reached via the gfx-family fallback (no product_name).
-
-    Mirrors the 'rocminfo missing AND no /sys/.../product_name' case: the
-    overlay must NOT emit an accelerator stanza for a curated SKU when
-    there is no product name to pin a nodeSelector to (helm falls back to
-    runtime/values.yaml's hard-coded selector).
-    """
-
-    def test_fallback_path_skips_accelerator_stanza_for_curated_sku(self) -> None:
-        cfg = GpuConfig()
-        cfg.append(
-            SkuEntry(
-                accel_key="strix",
-                product_name="",  # fallback path
-                gpu_target="gfx1150",
-                accel_env="",
-                quota_rate=2,
-                display_name="",
-            )
-        )
-        _, parsed = _render(cfg, courses=CourseSelection.default())
-        self.assertNotIn("accelerators", parsed["custom"])
-
-
-class TryLoadCoursesFromOverlayTests(unittest.TestCase):
-    """Round-trip CourseSelection through emit → write → re-read.
-
-    Guards the contract that ``rt upgrade`` relies on: a bare upgrade
-    must inherit whatever course selection the previous install wrote
-    into the overlay header.
-    """
-
-    def _write_and_read_back(self, courses: CourseSelection) -> CourseSelection | None:
-        cfg = _strix_halo_cfg()
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "values.local.yaml"
-            generate_values_overlay(
-                cfg,
-                image_registry="ghcr.io/amdresearch",
-                image_tag="v1.0",
-                courses=courses,
-                offline_mode=False,
-                overlay_path=path,
-            )
-            return try_load_courses_from_overlay(path)
-
-    def test_env_selection_header_round_trips(self) -> None:
-        loaded = self._write_and_read_back(CourseSelection.default())
-        self.assertIsNotNone(loaded)
+def test_legacy_course_selection_header_still_loads() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "values.local.yaml"
+        path.write_text("# Course selection : cpu, gpu\ncustom: {}\n", encoding="utf-8")
+        loaded = try_load_courses_from_overlay(path)
         assert loaded is not None
-        self.assertTrue(loaded.is_default())
-
-    def test_legacy_course_selection_header_still_loads(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "values.local.yaml"
-            path.write_text("# Course selection : cpu, gpu\ncustom: {}\n", encoding="utf-8")
-            loaded = try_load_courses_from_overlay(path)
-            self.assertIsNotNone(loaded)
-            assert loaded is not None
-            self.assertEqual(loaded.picks, ["cpu", "gpu"])
-
-    def test_basic_preset_round_trips(self) -> None:
-        original = CourseSelection(picks=list(COURSE_PRESET_BASIC))
-        loaded = self._write_and_read_back(original)
-        self.assertIsNotNone(loaded)
-        assert loaded is not None
-        self.assertEqual(loaded.picks, original.picks)
-
-    def test_none_sentinel_round_trips(self) -> None:
-        loaded = self._write_and_read_back(CourseSelection(picks=[NONE_SENTINEL]))
-        self.assertIsNotNone(loaded)
-        assert loaded is not None
-        self.assertTrue(loaded.is_none())
-
-    def test_custom_subset_round_trips(self) -> None:
-        original = CourseSelection(picks=["cpu", "Course-CV"])
-        loaded = self._write_and_read_back(original)
-        self.assertIsNotNone(loaded)
-        assert loaded is not None
-        self.assertEqual(loaded.picks, ["cpu", "Course-CV"])
-
-    def test_missing_file_returns_none(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            self.assertIsNone(try_load_courses_from_overlay(Path(tmp) / "nope.yaml"))
-
-    def test_overlay_without_header_returns_none(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "values.local.yaml"
-            path.write_text("custom: {}\n", encoding="utf-8")
-            self.assertIsNone(try_load_courses_from_overlay(path))
-
-    def test_unparseable_spec_returns_none(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "values.local.yaml"
-            path.write_text(
-                "# Course selection : not-a-real-key, also-fake\ncustom: {}\n",
-                encoding="utf-8",
-            )
-            self.assertIsNone(try_load_courses_from_overlay(path))
+        assert loaded.picks == ["cpu", "gpu"]
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_basic_preset_round_trips() -> None:
+    original = CourseSelection(picks=list(COURSE_PRESET_BASIC))
+    loaded = _write_and_read_back(original)
+    assert loaded is not None
+    assert loaded.picks == original.picks
+
+
+def test_none_sentinel_round_trips() -> None:
+    loaded = _write_and_read_back(CourseSelection(picks=[NONE_SENTINEL]))
+    assert loaded is not None
+    assert loaded.is_none()
+
+
+def test_custom_subset_round_trips() -> None:
+    original = CourseSelection(picks=["cpu", "Course-CV"])
+    loaded = _write_and_read_back(original)
+    assert loaded is not None
+    assert loaded.picks == ["cpu", "Course-CV"]
+
+
+def test_missing_file_returns_none() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        assert try_load_courses_from_overlay(Path(tmp) / "nope.yaml") is None
+
+
+def test_overlay_without_header_returns_none() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "values.local.yaml"
+        path.write_text("custom: {}\n", encoding="utf-8")
+        assert try_load_courses_from_overlay(path) is None
+
+
+def test_unparseable_spec_returns_none() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "values.local.yaml"
+        path.write_text(
+            "# Course selection : not-a-real-key, also-fake\ncustom: {}\n",
+            encoding="utf-8",
+        )
+        assert try_load_courses_from_overlay(path) is None


### PR DESCRIPTION
## Summary
- Convert `tests/installer` from `unittest` to pytest (plain functions, `pytest.raises`, `parametrize` for former `subTest` cases).
- Add `[tool.pytest.ini_options]` and a `test` optional dependency group in `pyproject.toml`.
- Update the `installer-tests` job in `.github/workflows/lint.yml` to run `python -m pytest tests/installer -v`.

## Test plan
- [x] `python -m pytest tests/installer -v` — 129 passed locally
- [x] `ruff check tests/installer` and `ruff format --check tests/installer` pass
- [ ] CI `Lint` workflow `Installer Unit Tests` job passes on this PR


Made with [Cursor](https://cursor.com)