### PR TITLE
Add read user and org to the scope

### DIFF
--- a/runtime/values-multi-nodes.yaml.example
+++ b/runtime/values-multi-nodes.yaml.example
@@ -387,7 +387,9 @@ hub:
         - your-github-org
       # Use [] for GitHub App credentials. For legacy OAuth Apps, use
       # read:user and read:org instead.
-      scope: []
+      scope:
+        - read:user
+        - read:org
 
     KubeSpawner:
       image_pull_policy: IfNotPresent


### PR DESCRIPTION
## Summary

Include `read:user` and `read:org` to the scope to allow users to launch environments

## Changes

Add  `read:user` and `read:org` to the scope

## Testing

In local deployment

## Files Changed

`runtime/values-multi-nodes.yaml.example`

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Tested on local Kubernetes cluster
- [x] Documentation links updated
