### PR TITLE
feat(notebook): add Jupyter AI baseline

### DIFF
--- a/dockerfiles/Base/Dockerfile.cpu
+++ b/dockerfiles/Base/Dockerfile.cpu
@@ -79,6 +79,9 @@ ARG NOTEBOOK_VERSION="7.5.5"
 ARG IPYWIDGETS_VERSION="8.1.8"
 ARG IPYKERNEL_VERSION="6.31.0"
 ARG JUPYTER_AI_VERSION="3.0.0"
+ARG JUPYTER_RESOURCE_USAGE_VERSION="1.2.1"
+ARG JUPYTER_RUFF_VERSION="0.3.1"
+ARG JUPYTEXT_VERSION="1.19.3"
 ARG OPENCODE_VERSION="1.17.7"
 ARG NB_UID=1000
 ARG PIP_INDEX_URL=
@@ -108,7 +111,10 @@ RUN if [ -n "$JUPYTERHUB_VERSION" ]; then python3 -mpip install --no-cache --upg
     ipykernel=="$IPYKERNEL_VERSION"; fi
 
 RUN python3 -mpip install --no-cache-dir \
-    jupyter-ai=="$JUPYTER_AI_VERSION"
+    jupyter-ai=="$JUPYTER_AI_VERSION" \
+    jupyter-resource-usage=="$JUPYTER_RESOURCE_USAGE_VERSION" \
+    jupyter-ruff=="$JUPYTER_RUFF_VERSION" \
+    jupytext=="$JUPYTEXT_VERSION"
 
 COPY dockerfiles/Base/jupyterlab-settings/overrides.json /tmp/auplc-jupyterlab-overrides.json
 

--- a/dockerfiles/Base/Dockerfile.cpu
+++ b/dockerfiles/Base/Dockerfile.cpu
@@ -78,7 +78,24 @@ ARG JUPYTERLAB_VERSION="4.5.6"
 ARG NOTEBOOK_VERSION="7.5.5"
 ARG IPYWIDGETS_VERSION="8.1.8"
 ARG IPYKERNEL_VERSION="6.31.0"
+ARG JUPYTER_AI_VERSION="3.0.0"
+ARG OPENCODE_VERSION="1.17.7"
+ARG NB_UID=1000
 ARG PIP_INDEX_URL=
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN HOME=/tmp/opencode-install \
+    bash -c "curl -fsSL https://opencode.ai/install | bash -s -- --version ${OPENCODE_VERSION} --no-modify-path" && \
+    install -m 0755 /tmp/opencode-install/.opencode/bin/opencode /usr/local/bin/opencode && \
+    rm -rf /tmp/opencode-install
+
+USER ${NB_UID}
 
 # Set pip index URL if specified
 RUN if [ -n "${PIP_INDEX_URL}" ]; then pip config set global.index-url "${PIP_INDEX_URL}"; fi
@@ -89,6 +106,13 @@ RUN if [ -n "$JUPYTERHUB_VERSION" ]; then python3 -mpip install --no-cache --upg
     notebook=="$NOTEBOOK_VERSION" \
     ipywidgets=="$IPYWIDGETS_VERSION" \
     ipykernel=="$IPYKERNEL_VERSION"; fi
+
+RUN python3 -mpip install --no-cache-dir \
+    jupyter-ai=="$JUPYTER_AI_VERSION"
+
+COPY dockerfiles/Base/jupyterlab-settings/overrides.json /tmp/auplc-jupyterlab-overrides.json
+
+RUN python3 -c "import pathlib, shutil, sys; target = pathlib.Path(sys.prefix) / 'share/jupyter/lab/settings/overrides.json'; target.parent.mkdir(parents=True, exist_ok=True); shutil.copyfile('/tmp/auplc-jupyterlab-overrides.json', target)"
 
 COPY --from=runtime-status-builder --chown=1000:100 /build/runtime/notebook/jupyterlab-runtime-status /tmp/auplc-jupyterlab-runtime-status
 

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -91,6 +91,9 @@ ARG PYTORCH_VERSION=2.9.1
 ARG TORCHVISION_VERSION=0.24.0
 ARG TORCHAUDIO_VERSION=2.9.0
 ARG JUPYTER_AI_VERSION=3.0.0
+ARG JUPYTER_RESOURCE_USAGE_VERSION=1.2.1
+ARG JUPYTER_RUFF_VERSION=0.3.1
+ARG JUPYTEXT_VERSION=1.19.3
 ARG OPENCODE_VERSION=1.17.7
 # PyTorch wheel target — only differs from GPU_TARGET for the generic
 # buckets (gfx110x → gfx110X-all, gfx120x → gfx120X-all). Specific targets
@@ -213,7 +216,10 @@ RUN pip3 install --no-cache-dir \
     tqdm
 
 RUN pip3 install --no-cache-dir \
-    jupyter-ai=="${JUPYTER_AI_VERSION}"
+    jupyter-ai=="${JUPYTER_AI_VERSION}" \
+    jupyter-resource-usage=="${JUPYTER_RESOURCE_USAGE_VERSION}" \
+    jupyter-ruff=="${JUPYTER_RUFF_VERSION}" \
+    jupytext=="${JUPYTEXT_VERSION}"
 
 RUN HOME=/tmp/opencode-install \
     bash -c "curl -fsSL https://opencode.ai/install | bash -s -- --version ${OPENCODE_VERSION} --no-modify-path" && \

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -90,6 +90,8 @@ ARG ROCM_VERSION=7.13.0
 ARG PYTORCH_VERSION=2.9.1
 ARG TORCHVISION_VERSION=0.24.0
 ARG TORCHAUDIO_VERSION=2.9.0
+ARG JUPYTER_AI_VERSION=3.0.0
+ARG OPENCODE_VERSION=1.17.7
 # PyTorch wheel target — only differs from GPU_TARGET for the generic
 # buckets (gfx110x → gfx110X-all, gfx120x → gfx120X-all). Specific targets
 # like gfx1150/gfx1151/gfx1152 use the same name in both apt and wheel repos.
@@ -202,7 +204,6 @@ RUN pip3 install --no-cache-dir \
     ipywidgets==8.1.8 \
     ipykernel==6.31.0 \
     matplotlib \
-    uv \
     seaborn \
     scikit-learn \
     numpy \
@@ -210,6 +211,18 @@ RUN pip3 install --no-cache-dir \
     hiredis \
     pillow \
     tqdm
+
+RUN pip3 install --no-cache-dir \
+    jupyter-ai=="${JUPYTER_AI_VERSION}"
+
+RUN HOME=/tmp/opencode-install \
+    bash -c "curl -fsSL https://opencode.ai/install | bash -s -- --version ${OPENCODE_VERSION} --no-modify-path" && \
+    install -m 0755 /tmp/opencode-install/.opencode/bin/opencode /usr/local/bin/opencode && \
+    rm -rf /tmp/opencode-install
+
+COPY dockerfiles/Base/jupyterlab-settings/overrides.json /tmp/auplc-jupyterlab-overrides.json
+
+RUN python3 -c "import pathlib, shutil, sys; target = pathlib.Path(sys.prefix) / 'share/jupyter/lab/settings/overrides.json'; target.parent.mkdir(parents=True, exist_ok=True); shutil.copyfile('/tmp/auplc-jupyterlab-overrides.json', target)"
 
 COPY --from=runtime-status-builder /build/runtime/notebook/jupyterlab-runtime-status /tmp/auplc-jupyterlab-runtime-status
 

--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -207,6 +207,7 @@ RUN pip3 install --no-cache-dir \
     ipywidgets==8.1.8 \
     ipykernel==6.31.0 \
     matplotlib \
+    uv \
     seaborn \
     scikit-learn \
     numpy \

--- a/dockerfiles/Base/jupyterlab-settings/overrides.json
+++ b/dockerfiles/Base/jupyterlab-settings/overrides.json
@@ -1,0 +1,25 @@
+{
+  "@jupyterlab/application-extension:shell": {
+    "layout": {
+      "single": {
+        "Linked Console": {
+          "area": "down"
+        },
+        "Inspector": {
+          "area": "down"
+        },
+        "Cloned Output": {
+          "area": "down"
+        },
+        "JupyterlabChat:sidepanel": {
+          "area": "right"
+        }
+      },
+      "multiple": {
+        "JupyterlabChat:sidepanel": {
+          "area": "right"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- install Jupyter AI and OpenCode in CPU and ROCm base notebook images
- set the Jupyter AI chat side panel to open on the right by default
- bundle low-friction JupyterLab productivity plugins: resource usage, Ruff formatting, and Jupytext

## Verification
- built the CPU base image locally with `docker build -f dockerfiles/Base/Dockerfile.cpu -t auplc-jupyter-ai-baseline:test .`
- ran the image locally on `127.0.0.1:18888` and confirmed `/lab` returns HTTP 200
- verified `opencode --version` reports `1.17.7` and `opencode acp --help` works
- verified Python packages: `jupyter-ai==3.0.0`, `jupyter-resource-usage==1.2.1`, `jupyter-ruff==0.3.1`, `jupytext==1.19.3`
- ran `python3 -m pip check` successfully in the test image
- ran JSON validation and `git diff --check`

## Notes
- rocLENS MCP integration is intentionally not included in this PR
- API/provider credentials are not baked into the images