### PR TITLE
Fix link to GitHub App in index

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -51,7 +51,7 @@ AUP Learning Cloud is a tailored JupyterHub deployment designed to provide an in
    jupyterhub/admin-manual
    jupyterhub/quota-system
    jupyterhub/monitoring
-   jupyterhub/github-oauth-setup
+   jupyterhub/github-app-setup
 
 .. toctree::
    :maxdepth: 1

--- a/source/jupyterhub/index.md
+++ b/source/jupyterhub/index.md
@@ -11,4 +11,4 @@ This section provides comprehensive guides for configuring and managing your Jup
 - {doc}`admin-manual` - Run common administrator workflows
 - {doc}`quota-system` - Configure quotas
 - {doc}`monitoring` - Connect Hub metrics to Prometheus and Grafana
-- {doc}`github-oauth-setup` - GitHub App setup
+- {doc}`github-app-setup` - GitHub App setup


### PR DESCRIPTION
## Summary

This PR #135 introduce filename changes but missed the index. So now the documentation does not include this page in the index