### PR TITLE
feat(hub): support configurable resource group order

### DIFF
--- a/runtime/chart/values.schema.yaml
+++ b/runtime/chart/values.schema.yaml
@@ -3368,6 +3368,22 @@ properties:
                 cpu: "ghcr.io/amdresearch/auplc-default:latest"
                 Course-DL: "ghcr.io/amdresearch/auplc-dl:latest"
               ```
+          groupOrder:
+            type: array
+            items:
+              type: string
+            description: |
+              Optional display order for resource groups in the Home and Spawn UI.
+              Groups listed here are shown first in the given order. Groups not
+              listed here keep the default ordering.
+
+              Example:
+              ```yaml
+              groupOrder:
+                - DEVELOPMENT
+                - COURSE
+                - CUSTOM REPO
+              ```
           requirements:
             type: object
             additionalProperties:

--- a/runtime/hub/core/config.py
+++ b/runtime/hub/core/config.py
@@ -117,6 +117,7 @@ class ResourcesConfig(BaseModel):
     images: dict[str, str] = Field(default_factory=dict)
     requirements: dict[str, ResourceRequirements] = Field(default_factory=dict)
     metadata: dict[str, ResourceMetadata] = Field(default_factory=dict)
+    groupOrder: list[str] = Field(default_factory=list)
 
     model_config = {"extra": "allow"}
 

--- a/runtime/hub/core/handlers.py
+++ b/runtime/hub/core/handlers.py
@@ -968,10 +968,20 @@ class ResourcesAPIHandler(APIHandler):
                 groups_dict[group_name] = []
             groups_dict[group_name].append(resource_data)
 
-        # Build groups list - sort alphabetically, but put CUSTOM REPO last
+        # Build groups list. Configured groups come first; unspecified groups
+        # keep the legacy alphabetical order with low-priority groups last.
         BOTTOM_GROUPS = {"OTHERS", "CUSTOM REPO"}
         groups_list = []
-        sorted_group_names = sorted(groups_dict.keys(), key=lambda x: (x in BOTTOM_GROUPS, x))
+        configured_group_order = {
+            group_name: index for index, group_name in enumerate(config.resources.groupOrder)
+        }
+
+        def group_sort_key(group_name: str) -> tuple[int, int, bool, str]:
+            if group_name in configured_group_order:
+                return (0, configured_group_order[group_name], False, group_name)
+            return (1, 0, group_name in BOTTOM_GROUPS, group_name)
+
+        sorted_group_names = sorted(groups_dict.keys(), key=group_sort_key)
         for group_name in sorted_group_names:
             groups_list.append(
                 {

--- a/runtime/hub/core/handlers.py
+++ b/runtime/hub/core/handlers.py
@@ -972,9 +972,7 @@ class ResourcesAPIHandler(APIHandler):
         # keep the legacy alphabetical order with low-priority groups last.
         BOTTOM_GROUPS = {"OTHERS", "CUSTOM REPO"}
         groups_list = []
-        configured_group_order = {
-            group_name: index for index, group_name in enumerate(config.resources.groupOrder)
-        }
+        configured_group_order = {group_name: index for index, group_name in enumerate(config.resources.groupOrder)}
 
         def group_sort_key(group_name: str) -> tuple[int, int, bool, str]:
             if group_name in configured_group_order:

--- a/runtime/values.yaml
+++ b/runtime/values.yaml
@@ -253,6 +253,14 @@ custom:
       Course-PhySim: "ghcr.io/amdresearch/auplc-physim:latest"
       # Custom-URL: "ghcr.io/amdresearch/auplc-cv:latest"
 
+    # Optional spawn/Home group display order. Groups not listed here are shown
+    # after these entries using the default alphabetical order.
+    # Example: move DEVELOPMENT before COURSE by listing DEVELOPMENT first.
+    groupOrder:
+      - COURSE
+      - DEVELOPMENT
+      - CUSTOM REPO
+
     # Course Resource Requirements
     # Define resource quotas for each course
     requirements:


### PR DESCRIPTION
## Summary
- Add custom.resources.groupOrder support for Home/Spawn resource group ordering
- Document the new value in runtime/values.yaml and Helm schema
- Preserve legacy ordering for groups omitted from groupOrder or when groupOrder is unset

## Validation
- python -m py_compile runtime/hub/core/config.py runtime/hub/core/handlers.py
- Parsed runtime/values.yaml and runtime/chart/values.schema.yaml with yaml.safe_load
- Checked missing-group fallback ordering