### PR TITLE
fix(hub): decouple GitHub username prefix from login_service label

### DIFF
--- a/runtime/hub/core/authenticators/__init__.py
+++ b/runtime/hub/core/authenticators/__init__.py
@@ -25,7 +25,7 @@ Provides various authentication methods for JupyterHub.
 
 from core.authenticators.auto_login import AutoLoginAuthenticator
 from core.authenticators.firstuse import CustomFirstUseAuthenticator
-from core.authenticators.github_app import CustomGitHubOAuthenticator, GITHUB_USERNAME_PREFIX
+from core.authenticators.github_app import GITHUB_USERNAME_PREFIX, CustomGitHubOAuthenticator
 from core.authenticators.jwt import RemoteLabAuthenticator
 from core.authenticators.multi import CustomMultiAuthenticator
 

--- a/runtime/hub/core/authenticators/__init__.py
+++ b/runtime/hub/core/authenticators/__init__.py
@@ -25,7 +25,7 @@ Provides various authentication methods for JupyterHub.
 
 from core.authenticators.auto_login import AutoLoginAuthenticator
 from core.authenticators.firstuse import CustomFirstUseAuthenticator
-from core.authenticators.github_app import CustomGitHubOAuthenticator
+from core.authenticators.github_app import CustomGitHubOAuthenticator, GITHUB_USERNAME_PREFIX
 from core.authenticators.jwt import RemoteLabAuthenticator
 from core.authenticators.multi import CustomMultiAuthenticator
 
@@ -64,4 +64,5 @@ __all__ = [
     "CustomMultiAuthenticator",
     "create_authenticator",
     "LOCAL_ACCOUNT_PREFIX",
+    "GITHUB_USERNAME_PREFIX",
 ]

--- a/runtime/hub/core/authenticators/github_app.py
+++ b/runtime/hub/core/authenticators/github_app.py
@@ -35,6 +35,8 @@ from traitlets import Int, Unicode
 
 log = logging.getLogger("jupyterhub.auth.github")
 
+GITHUB_USERNAME_PREFIX = "github:"
+
 
 class _GitHubAppInstallCallbackHandler(OAuthCallbackHandler):
     """Callback handler that gracefully handles GitHub App installation redirects.
@@ -57,6 +59,7 @@ class CustomGitHubOAuthenticator(GitHubOAuthenticator):
     """GitHub App authenticator with access token preservation and refresh."""
 
     name = "github"
+    prefix = GITHUB_USERNAME_PREFIX
     callback_handler = _GitHubAppInstallCallbackHandler
 
     app_id = Unicode(

--- a/runtime/hub/core/groups.py
+++ b/runtime/hub/core/groups.py
@@ -39,6 +39,8 @@ from jupyterhub.orm import Group as ORMGroup
 from jupyterhub.user import User as JupyterHubUser
 from sqlalchemy.orm import Session
 
+from core.authenticators.github_app import GITHUB_USERNAME_PREFIX
+
 log = logging.getLogger("jupyterhub.groups")
 
 GITHUB_TEAM_SOURCE = "github-team"
@@ -548,7 +550,7 @@ async def sync_github_teams_for_user(
     protection. Concurrent spawns for the same user coalesce into one set of
     GitHub team membership checks within the TTL window.
     """
-    if not user.name.startswith("github:") or not app_id:
+    if not user.name.startswith(GITHUB_USERNAME_PREFIX) or not app_id:
         return False
 
     lock = _GITHUB_TEAM_SYNC_LOCKS.setdefault(user.name, asyncio.Lock())
@@ -714,7 +716,7 @@ def resolve_resources_for_user(
     if available_resources:
         return available_resources
 
-    if not username.startswith("github:"):
+    if not username.startswith(GITHUB_USERNAME_PREFIX):
         return team_resource_mapping.get("native-users", team_resource_mapping.get("official", []))
 
     return ["none"]

--- a/runtime/hub/core/handlers.py
+++ b/runtime/hub/core/handlers.py
@@ -41,7 +41,7 @@ from multiauthenticator import MultiAuthenticator
 from pydantic import ValidationError
 from tornado import web
 
-from core.authenticators import CustomFirstUseAuthenticator
+from core.authenticators import GITHUB_USERNAME_PREFIX, CustomFirstUseAuthenticator
 from core.git_validation import validate_and_sanitize_repo_url
 from core.notifications import get_normalized_notifications
 from core.quota import (
@@ -265,7 +265,7 @@ class ChangePasswordHandler(BaseHandler):
             return self.finish(html)
 
         username = user.name
-        if username.startswith("github:"):
+        if username.startswith(GITHUB_USERNAME_PREFIX):
             html = await _render_error("GitHub users cannot change password here")
             self.set_status(400)
             return self.finish(html)
@@ -322,7 +322,7 @@ class AdminResetPasswordHandler(BaseHandler):
         from jupyterhub.orm import User
 
         for user in self.db.query(User).all():
-            if not user.name.startswith("github:") and user.name != "admin":
+            if not user.name.startswith(GITHUB_USERNAME_PREFIX) and user.name != "admin":
                 native_users.append(user.name)
 
         html = await self.render_template(
@@ -356,7 +356,7 @@ class AdminResetPasswordHandler(BaseHandler):
             )
 
         username = target_user
-        if username.startswith("github:"):
+        if username.startswith(GITHUB_USERNAME_PREFIX):
             return self.redirect(
                 self.hub.base_url
                 + f"admin/reset-password?user={target_user}&error=Cannot+reset+password+for+GitHub+users"
@@ -438,7 +438,7 @@ class AdminAPISetPasswordHandler(APIHandler):
                 self.set_header("Content-Type", "application/json")
                 return self.finish(json.dumps({"error": "Username and password are required"}))
 
-            if username.startswith("github:"):
+            if username.startswith(GITHUB_USERNAME_PREFIX):
                 self.set_status(400)
                 self.set_header("Content-Type", "application/json")
                 return self.finish(json.dumps({"error": "Cannot set password for GitHub users"}))
@@ -532,7 +532,7 @@ class AdminAPIBatchSetPasswordHandler(APIHandler):
                     self.set_status(400)
                     self.set_header("Content-Type", "application/json")
                     return self.finish(json.dumps({"error": "Each entry must have username and password"}))
-                if entry.get("username", "").startswith("github:"):
+                if entry.get("username", "").startswith(GITHUB_USERNAME_PREFIX):
                     self.set_status(400)
                     self.set_header("Content-Type", "application/json")
                     return self.finish(
@@ -1583,7 +1583,7 @@ class GroupSyncAPIHandler(APIHandler):
         skipped = 0
 
         for user in self.users.values():
-            if not user.name.startswith("github:"):
+            if not user.name.startswith(GITHUB_USERNAME_PREFIX):
                 skipped += 1
                 continue
 

--- a/runtime/hub/core/setup.py
+++ b/runtime/hub/core/setup.py
@@ -65,6 +65,7 @@ def setup_hub(c: Any) -> None:
     """
     from core import z2jh
     from core.authenticators import (
+        GITHUB_USERNAME_PREFIX,
         CustomFirstUseAuthenticator,
         CustomGitHubOAuthenticator,
         create_authenticator,
@@ -121,7 +122,7 @@ def setup_hub(c: Any) -> None:
         if auth_state is None:
             spawner.github_access_token = None
             # Still assign native users to their default group
-            if not spawner.user.name.startswith("github:"):
+            if not spawner.user.name.startswith(GITHUB_USERNAME_PREFIX):
                 try:
                     from core.groups import assign_user_to_group
 
@@ -131,7 +132,7 @@ def setup_hub(c: Any) -> None:
             return
         spawner.github_access_token = auth_state.get("access_token")
 
-        if spawner.user.name.startswith("github:"):
+        if spawner.user.name.startswith(GITHUB_USERNAME_PREFIX):
             try:
                 from core.groups import sync_github_teams_for_user
 
@@ -160,7 +161,7 @@ def setup_hub(c: Any) -> None:
                 assign_user_to_group(spawner.user, "github-users", spawner.user.db)
             except Exception as e:
                 print(f"[GROUPS] Warning: Failed to assign github-users group for {spawner.user.name}: {e}")
-        elif not spawner.user.name.startswith("github:"):
+        elif not spawner.user.name.startswith(GITHUB_USERNAME_PREFIX):
             # Native user with auth_state but no GitHub teams
             try:
                 from core.groups import assign_user_to_group

--- a/runtime/hub/tests/test_groups.py
+++ b/runtime/hub/tests/test_groups.py
@@ -51,6 +51,16 @@ if "core" not in sys.modules:
     core_module.__path__ = [str(CORE)]
     sys.modules["core"] = core_module
 
+if "core.authenticators" not in sys.modules:
+    authenticators_module = types.ModuleType("core.authenticators")
+    authenticators_module.__path__ = [str(CORE / "authenticators")]
+    sys.modules["core.authenticators"] = authenticators_module
+
+if "core.authenticators.github_app" not in sys.modules:
+    github_app_module = types.ModuleType("core.authenticators.github_app")
+    github_app_module.GITHUB_USERNAME_PREFIX = "github:"
+    sys.modules["core.authenticators.github_app"] = github_app_module
+
 
 def load_module(name: str, path: Path):
     spec = importlib.util.spec_from_file_location(name, path)


### PR DESCRIPTION
## Summary

The multiauthenticator library derives a user's identity prefix from the
  login_service display label, so the "github:" prefix that team sync, group
  assignment, and resource resolution depend on only worked because the
  default label happened to normalize to "github". Setting login_service to
  something like "GitHub Enterprise" would silently break every
  startswith("github:") check.

  Pin an explicit prefix on CustomGitHubOAuthenticator so identity no longer
  tracks the display label, and centralize the literal as GITHUB_USERNAME_PREFIX
  to replace the 10 scattered "github:" strings across setup, handlers, and
  groups.


## Changes

Define global `GITHUB_USERNAME_PREFIX`

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Tested on local Kubernetes cluster
- [x] Documentation links updated
