### PR TITLE
feat(hub): add configurable cluster display name

### DIFF
--- a/runtime/chart/values.yaml
+++ b/runtime/chart/values.yaml
@@ -38,6 +38,10 @@ custom:
   #   - multi: GitHub App + Local accounts
   authMode: "auto-login"
 
+  # Cluster display name (optional). Appended to "AUP Learning Cloud" in the UI.
+  # Example: "City/University" → "AUP Learning Cloud City/University"
+  clusterName: ""
+
   # Auto-create admin user on first install (optional)
   adminUser:
     enabled: false

--- a/runtime/hub/core/config.py
+++ b/runtime/hub/core/config.py
@@ -231,6 +231,7 @@ class HubConfig:
         self.auth_mode: str = "auto-login"
         self.single_node_mode: bool = False
         self.github_org_name: str = ""
+        self.cluster_name: str = ""
         self.quota_enabled: bool = False
 
         # Parsed configuration
@@ -268,6 +269,7 @@ class HubConfig:
         # Extract runtime settings
         instance.auth_mode = raw_config.get("authMode", "auto-login")
         instance.github_org_name = raw_config.get("githubOrgName", "")
+        instance.cluster_name = raw_config.get("clusterName", "")
 
         # Single-node mode: from config or auto-enable for auto-login
         single_node_mode = raw_config.get("singleNodeMode")
@@ -330,6 +332,13 @@ class HubConfig:
     # =========================================================================
     # Convenience Properties
     # =========================================================================
+
+    @property
+    def platform_display_name(self) -> str:
+        base = "AUP Learning Cloud"
+        if self.cluster_name:
+            return f"{base} {self.cluster_name}"
+        return base
 
     @property
     def resources(self) -> ResourcesConfig:

--- a/runtime/hub/core/handlers.py
+++ b/runtime/hub/core/handlers.py
@@ -73,6 +73,7 @@ _handler_config: dict[str, Any] = {
     "default_quota": 0,
     "team_resource_mapping": {},
     "auth_mode": "auto-login",
+    "platform_name": "AUP Learning Cloud",
 }
 
 
@@ -121,6 +122,7 @@ def configure_handlers(
     team_resource_mapping: dict[str, list[str]] | None = None,
     github_org: str = "",
     auth_mode: str = "auto-login",
+    platform_name: str = "AUP Learning Cloud",
 ) -> None:
     """Configure handler module with runtime settings."""
     if accelerator_options is not None:
@@ -134,6 +136,7 @@ def configure_handlers(
         _handler_config["team_resource_mapping"] = team_resource_mapping
     _handler_config["github_org"] = github_org
     _handler_config["auth_mode"] = auth_mode
+    _handler_config["platform_name"] = platform_name
 
 
 # =============================================================================
@@ -1313,14 +1316,15 @@ class PlatformInfoHandler(APIHandler):
     """
 
     async def get(self):
+        name = _handler_config.get("platform_name", "AUP Learning Cloud")
         self.set_header("Content-Type", "application/json")
-        self.set_header("X-Powered-By", "AUP Learning Cloud")
+        self.set_header("X-Powered-By", name)
         self.finish(
             json.dumps(
                 {
-                    "platform": "AUP Learning Cloud",
+                    "platform": name,
                     "vendor": "Advanced Micro Devices, Inc.",
-                    "powered_by": "AUP Learning Cloud",
+                    "powered_by": name,
                     "website": "https://github.com/AMDResearch/aup-learning-cloud",
                 }
             )

--- a/runtime/hub/core/setup.py
+++ b/runtime/hub/core/setup.py
@@ -202,6 +202,7 @@ def setup_hub(c: Any) -> None:
         team_resource_mapping=dict(config.teams.mapping),
         github_org=config.github_org_name,
         auth_mode=config.auth_mode,
+        platform_name=config.platform_display_name,
     )
 
     if not hasattr(c.JupyterHub, "extra_handlers") or c.JupyterHub.extra_handlers is None:
@@ -381,6 +382,8 @@ def setup_hub(c: Any) -> None:
         c.JupyterHub.template_vars = {}
     c.JupyterHub.template_vars["authenticator_mode"] = config.auth_mode  # type: ignore[assignment]
     c.JupyterHub.template_vars["hide_logout"] = config.auth_mode == "auto-login"  # type: ignore[assignment]
+    c.JupyterHub.template_vars["cluster_name"] = config.cluster_name  # type: ignore[assignment]
+    c.JupyterHub.template_vars["platform_name"] = config.platform_display_name  # type: ignore[assignment]
 
     print(f"[SETUP] Hub setup complete: auth_mode={config.auth_mode}")
     print(f"[SETUP] template_vars: {c.JupyterHub.template_vars}")

--- a/runtime/hub/frontend/apps/admin/src/App.tsx
+++ b/runtime/hub/frontend/apps/admin/src/App.tsx
@@ -22,7 +22,8 @@ import { UserList } from './pages/UserList';
 import { GroupList } from './pages/GroupList';
 import { Dashboard } from './pages/Dashboard';
 import { NavBar } from './components/NavBar';
-import { PLATFORM_NAME } from '@auplc/shared';
+import { useState, useEffect } from 'react';
+import { PLATFORM_NAME, fetchPlatformInfo } from '@auplc/shared';
 
 function App() {
 
@@ -30,9 +31,14 @@ function App() {
   const baseUrl = (jhdata.base_url || '/hub/').replace(/\/+$/, '');
   const basePath = `${baseUrl}/admin`;
 
+  const [platformName, setPlatformName] = useState(PLATFORM_NAME);
+  useEffect(() => {
+    fetchPlatformInfo().then(info => setPlatformName(info.platform)).catch(() => {});
+  }, []);
+
   return (
     <BrowserRouter basename={basePath}>
-      <div className="admin-page" data-platform={PLATFORM_NAME}>
+      <div className="admin-page" data-platform={platformName}>
         <NavBar />
         <Routes>
           <Route path="/users" element={<UserList />} />

--- a/runtime/hub/frontend/apps/admin/src/App.tsx
+++ b/runtime/hub/frontend/apps/admin/src/App.tsx
@@ -31,7 +31,7 @@ function App() {
   const baseUrl = (jhdata.base_url || '/hub/').replace(/\/+$/, '');
   const basePath = `${baseUrl}/admin`;
 
-  const [platformName, setPlatformName] = useState(PLATFORM_NAME);
+  const [platformName, setPlatformName] = useState<string>(PLATFORM_NAME);
   useEffect(() => {
     fetchPlatformInfo().then(info => setPlatformName(info.platform)).catch(() => {});
   }, []);

--- a/runtime/hub/frontend/apps/home/src/App.tsx
+++ b/runtime/hub/frontend/apps/home/src/App.tsx
@@ -194,7 +194,7 @@ function App() {
   const [showOnboardingModal, setShowOnboardingModal] = useState(false);
   const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>(0);
 
-  const [platformName, setPlatformName] = useState(PLATFORM_NAME);
+  const [platformName, setPlatformName] = useState<string>(PLATFORM_NAME);
 
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const toggleTheme = useCallback(() => {

--- a/runtime/hub/frontend/apps/home/src/App.tsx
+++ b/runtime/hub/frontend/apps/home/src/App.tsx
@@ -27,6 +27,7 @@ import {
   getResourceType,
   getResourceTypeLabel,
   PLATFORM_NAME,
+  fetchPlatformInfo,
 } from "@auplc/shared";
 import onboardingLaunchWorkspaceUrl from "./onboarding-launch-workspace.png";
 import onboardingResourcePickerUrl from "./onboarding-resource-picker.png";
@@ -193,6 +194,8 @@ function App() {
   const [showOnboardingModal, setShowOnboardingModal] = useState(false);
   const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>(0);
 
+  const [platformName, setPlatformName] = useState(PLATFORM_NAME);
+
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const toggleTheme = useCallback(() => {
     setTheme(t => {
@@ -200,6 +203,10 @@ function App() {
       applyTheme(next);
       return next;
     });
+  }, []);
+
+  useEffect(() => {
+    fetchPlatformInfo().then(info => setPlatformName(info.platform)).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -457,7 +464,7 @@ function App() {
             {getGreeting()}, {jhdata.user ?? "student"}
           </p>
           <h1>
-            Welcome to <span className="accent">{PLATFORM_NAME}</span>
+            Welcome to <span className="accent">{platformName}</span>
           </h1>
           <p className="hero-desc">
             Experience next-generation AI acceleration with AMD ROCm. Launch
@@ -874,7 +881,7 @@ function App() {
                 <div className="onboarding-step-layout onboarding-step-layout-welcome">
                   <div className="onboarding-panel-copy">
                     <span className="onboarding-kicker">Welcome</span>
-                    <h2 id="onboarding-modal-title">Welcome to {PLATFORM_NAME}</h2>
+                    <h2 id="onboarding-modal-title">Welcome to {platformName}</h2>
                     <p>
                       This short guide will show you how to get started, where to launch your environment,
                       and where to find AMD developer resources later.

--- a/runtime/hub/frontend/apps/spawn/src/App.tsx
+++ b/runtime/hub/frontend/apps/spawn/src/App.tsx
@@ -19,7 +19,7 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import type { Resource, Accelerator, GitHubRepo } from '@auplc/shared';
-import { validateRepo, fetchGitHubRepos, isCurrentUserGitHub, PLATFORM_NAME } from '@auplc/shared';
+import { validateRepo, fetchGitHubRepos, isCurrentUserGitHub, PLATFORM_NAME, fetchPlatformInfo } from '@auplc/shared';
 
 type Theme = 'light' | 'dark';
 function getInitialTheme(): Theme {
@@ -91,6 +91,7 @@ function App() {
   const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
   const [runtime, setRuntime] = useState(20);
   const [runtimeInput, setRuntimeInput] = useState('20');
+  const [platformName, setPlatformName] = useState(PLATFORM_NAME);
   const [repoUrl, setRepoUrl] = useState(initialRepoUrl);
   const [repoUrlError, setRepoUrlError] = useState('');
   const [repoValidating, setRepoValidating] = useState(false);
@@ -116,6 +117,10 @@ function App() {
   );
 
   const loading = resourcesLoading || acceleratorsLoading || quotaLoading;
+
+  useEffect(() => {
+    fetchPlatformInfo().then(info => setPlatformName(info.platform)).catch(() => {});
+  }, []);
 
   useEffect(() => {
     if (!initialRepoUrl || allowedGitProviders.length === 0) return;
@@ -351,7 +356,7 @@ function App() {
           </button>
         </div>
         <h1>Launch Your Server</h1>
-        <p>Select a resource, configure your environment, and launch on {PLATFORM_NAME}</p>
+        <p>Select a resource, configure your environment, and launch on {platformName}</p>
       </div>
 
       {/* Warnings */}

--- a/runtime/hub/frontend/apps/spawn/src/App.tsx
+++ b/runtime/hub/frontend/apps/spawn/src/App.tsx
@@ -91,7 +91,7 @@ function App() {
   const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
   const [runtime, setRuntime] = useState(20);
   const [runtimeInput, setRuntimeInput] = useState('20');
-  const [platformName, setPlatformName] = useState(PLATFORM_NAME);
+  const [platformName, setPlatformName] = useState<string>(PLATFORM_NAME);
   const [repoUrl, setRepoUrl] = useState(initialRepoUrl);
   const [repoUrlError, setRepoUrlError] = useState('');
   const [repoValidating, setRepoValidating] = useState(false);

--- a/runtime/hub/frontend/templates/admin.html
+++ b/runtime/hub/frontend/templates/admin.html
@@ -30,5 +30,5 @@ SOFTWARE.
   </div>
 {% endblock main %}
 {% block footer %}
-  <div class="py-2 px-4 bg-body-tertiary small version_footer">AUP Learning Cloud {{ server_version }}</div>
+  <div class="py-2 px-4 bg-body-tertiary small version_footer">{{ platform_name or 'AUP Learning Cloud' }} {{ server_version }}</div>
 {% endblock footer %}

--- a/runtime/hub/frontend/templates/home.html
+++ b/runtime/hub/frontend/templates/home.html
@@ -24,7 +24,7 @@ SOFTWARE.
   {% set announcement = announcement_home %}
 {% endif %}
 
-{%- block title -%}Home - AUP Learning Cloud{%- endblock title -%}
+{%- block title -%}Home - {{ platform_name or 'AUP Learning Cloud' }}{%- endblock title -%}
 
 {% block stylesheet %}
 {{ super() }}

--- a/runtime/hub/frontend/templates/login.html
+++ b/runtime/hub/frontend/templates/login.html
@@ -32,7 +32,7 @@ SOFTWARE.
 {% endblock login_widget %}
 
 {%- block title -%}
-AUP Learning Cloud
+{{ platform_name or 'AUP Learning Cloud' }}
 {%- endblock title -%}
 
 {% block stylesheet %}
@@ -88,7 +88,7 @@ AUP Learning Cloud
                 <polygon class="cls-1"
                     points="115.74 23.98 115.74 10.9 106.4 20.24 106.4 33.33 119.48 33.33 128.82 23.98 115.74 23.98" />
             </svg>
-            <h2 class="text-3xl md:text-4xl font-bold text-white mb-4">AUP Learning Cloud</h2>
+            <h2 class="text-3xl md:text-4xl font-bold text-white mb-4">{{ platform_name or 'AUP Learning Cloud' }}</h2>
             <p class="text-blue-100 mb-8">Experience the next generation of AI acceleration with AMD ROCm™.</p>
             {% if login_service %}
             <a role="button"
@@ -123,7 +123,7 @@ AUP Learning Cloud
             </script>
             <div class="bg-white rounded-xl shadow-lg p-8">
                 <div class="text-center mb-8">
-                    <h1 class="text-2xl font-bold text-gray-800">Login to AUP Learning Cloud</h1>
+                    <h1 class="text-2xl font-bold text-gray-800">Login to {{ platform_name or 'AUP Learning Cloud' }}</h1>
                     {% if authenticator_mode == 'dummy' %}
                     <p class="text-sm text-orange-600 mt-2">⚠️ Development Mode - Any username/password accepted</p>
                     {% endif %}

--- a/runtime/hub/frontend/templates/page.html
+++ b/runtime/hub/frontend/templates/page.html
@@ -58,7 +58,7 @@ SOFTWARE.
     <meta charset="utf-8">
     <title>
       {%- block title -%}
-         AUP Learning Cloud
+         {{ platform_name or 'AUP Learning Cloud' }}
       {%- endblock title -%}
     </title>
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
@@ -275,15 +275,15 @@ SOFTWARE.
     {% endblock require_config %}
     {# djlint: on #}
     {% block meta %}
-      <meta name="description" content="AUP Learning Cloud - AMD AI Learning Platform">
+      <meta name="description" content="{{ platform_name or 'AUP Learning Cloud' }} - AMD AI Learning Platform">
       <meta name="keywords" content="AMD, AI, Learning, Jupyter, Notebook">
-      <meta name="generator" content="{{ powered_by or 'AUP Learning Cloud' }}">
+      <meta name="generator" content="{{ powered_by or platform_name or 'AUP Learning Cloud' }}">
     {% endblock meta %}
   </head>
   <body>
     <noscript>
       <div id='noscript'>
-         AUP Learning Cloud requires JavaScript.
+         {{ platform_name or 'AUP Learning Cloud' }} requires JavaScript.
         <br>
         Please enable it to proceed.
       </div>
@@ -590,7 +590,7 @@ SOFTWARE.
                     target="_blank"
                     rel="noopener noreferrer"
                     style="font-weight:600;text-decoration:none;">
-        {{ powered_by or 'AUP Learning Cloud' }}
+        {{ powered_by or platform_name or 'AUP Learning Cloud' }}
       </a>
     </footer>
   </body>

--- a/runtime/values-multi-nodes.yaml.example
+++ b/runtime/values-multi-nodes.yaml.example
@@ -57,6 +57,10 @@ custom:
   # - multi: GitHub App + native first-use accounts
   authMode: "multi"
 
+  # Cluster display name (optional). Appended to "AUP Learning Cloud" in the UI.
+  # Example: "City/University" → "AUP Learning Cloud City/University"
+  clusterName: ""
+
   # GitHub organization name for team-based resource access
   githubOrgName: "your-github-org"
 

--- a/runtime/values.yaml
+++ b/runtime/values.yaml
@@ -50,6 +50,10 @@ custom:
   # - multi: GitHub App + Local accounts
   authMode: "auto-login"
 
+  # Cluster display name (optional). Appended to "AUP Learning Cloud" in the UI.
+  # Example: "City/University" → "AUP Learning Cloud City/University"
+  clusterName: ""
+
   # Auto-create admin user on first install
   adminUser:
     enabled: false


### PR DESCRIPTION
## Summary
  - Add `custom.clusterName` values option that appends to "AUP Learning Cloud" across the UI
  - When empty (default), no change from current behavior
  - Propagates through Jinja templates (login, home, admin, page title, footer), React apps (home welcome, spawn, admin), and the `/hub/api/platform` endpoint

  ## Usage
  ```yaml
  custom:
    clusterName: "Dublin"
  ```

  Renders as "AUP Learning Cloud Dublin" in the browser tab, login page, welcome message, footer, and API.
## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Tested on local Kubernetes cluster
- [x] Documentation links updated
