### PR TITLE
fix(hub): hide left-panel login button in multi-auth modes

### DIFF
--- a/runtime/hub/frontend/templates/login.html
+++ b/runtime/hub/frontend/templates/login.html
@@ -90,7 +90,7 @@ AUP Learning Cloud
             </svg>
             <h2 class="text-3xl md:text-4xl font-bold text-white mb-4">AUP Learning Cloud</h2>
             <p class="text-blue-100 mb-8">Experience the next generation of AI acceleration with AMD ROCm™.</p>
-            {% if login_service %}
+            {% if login_service and not authenticator_mode.startswith('multi') %}
             <a role="button"
                 class='inline-block bg-white hover:bg-gray-100 text-black font-medium py-2 px-4 rounded transition duration-300'
                 href='{{ authenticator_login_url | safe }}'>


### PR DESCRIPTION
## Summary

- On failed native login in `multi` auth mode, JupyterHub re-renders with the sub-authenticator's `login_service`, causing a "Sign in with Native" button to appear on the left panel
  - This is confusing since the right panel already has the full multi-auth form
  - Fix: skip the left-panel button when `authenticator_mode` starts with `multi`

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Tested on local Kubernetes cluster
- [x] Documentation links updated
