### PR TITLE
feat(jupyter-ai): persist LiteLLM API keys via ~/.env symlink

### DIFF
--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -293,6 +293,14 @@ COPY dockerfiles/Base/jupyter-ai/mcp_settings.json /opt/workspace/.jupyter/mcp_s
 COPY dockerfiles/Base/notebooks/*.ipynb /opt/workspace/examples/
 RUN chown -R $NB_UID:$NB_GID /opt/workspace
 
+# Template of Jupyter AI / LiteLLM API keys. The singleuser postStart hook
+# (singleuser.lifecycleHooks in the Helm chart) seeds this to the persistent
+# home (~/.env) on first launch and symlinks it into each course workspace, so
+# students set their key once and it survives across sessions and courses.
+RUN mkdir -p /opt/auplc
+COPY dockerfiles/Base/jupyter-ai/dot-env.example /opt/auplc/jupyter-ai.env.example
+RUN chown -R $NB_UID:$NB_GID /opt/auplc
+
 # Create startup script - ensuring it exists in the correct location
 RUN echo '#!/bin/bash' > /home/$NB_USER/start-jupyter.sh && \
     echo 'export USER=jovyan' >> /home/$NB_USER/start-jupyter.sh && \

--- a/dockerfiles/Base/jupyter-ai/dot-env.example
+++ b/dockerfiles/Base/jupyter-ai/dot-env.example
@@ -1,0 +1,50 @@
+# ============================================================================
+# AUP Learning Cloud — Jupyter AI / LiteLLM API keys
+# ============================================================================
+# This file lives on your PERSISTENT home (~/.env) and is symlinked into every
+# course workspace automatically, so you only have to set your key ONCE and it
+# survives across sessions and across courses.
+#
+# How to use:
+#   1. Fill in the value for the provider whose model you want to use.
+#   2. Save the file. (The "Add secret" button on the Jupyter AI settings page
+#      writes here too — both ways update the same file.)
+#   3. Pick the matching model in the Jupyternaut settings panel.
+#
+# You normally only need ONE key — the one for the model you select.
+# Leave the rest blank. Lines starting with '#' are ignored.
+# The model strings below are illustrative; see your provider for exact names.
+# ----------------------------------------------------------------------------
+
+# OpenAI            e.g. openai/gpt-4o, openai/gpt-4o-mini
+OPENAI_API_KEY=
+
+# Anthropic         e.g. anthropic/claude-3-5-sonnet-latest
+ANTHROPIC_API_KEY=
+
+# Google Gemini     e.g. gemini/gemini-1.5-pro, gemini/gemini-1.5-flash
+GEMINI_API_KEY=
+
+# Mistral           e.g. mistral/mistral-large-latest
+MISTRAL_API_KEY=
+
+# Groq              e.g. groq/llama-3.1-70b-versatile
+GROQ_API_KEY=
+
+# Cohere            e.g. cohere/command-r-plus
+COHERE_API_KEY=
+
+# Together AI       e.g. together_ai/meta-llama/Llama-3-70b-chat-hf
+TOGETHERAI_API_KEY=
+
+# Hugging Face      e.g. huggingface/meta-llama/Llama-3-8B-Instruct
+HUGGINGFACE_API_KEY=
+
+# OpenRouter        e.g. openrouter/anthropic/claude-3.5-sonnet
+OPENROUTER_API_KEY=
+
+# --- Custom / self-hosted LiteLLM proxy or OpenAI-compatible endpoint -------
+# If you point Jupyternaut at your own LiteLLM proxy, set the key + base URL of
+# that endpoint instead (uncomment and fill in):
+# OPENAI_API_KEY=sk-...
+# OPENAI_BASE_URL=https://your-litellm-proxy.example.com

--- a/runtime/chart/values.yaml
+++ b/runtime/chart/values.yaml
@@ -533,7 +533,12 @@ singleuser:
         command:
           - "sh"
           - "-c"
-          - 't=/opt/auplc/jupyter-ai.env.example; e=/home/jovyan/.env; if [ ! -e "$e" ] && [ -f "$t" ]; then cp "$t" "$e" && chmod 600 "$e"; fi; d="$(pwd)"; [ "$d" = "/home/jovyan" ] || ln -sf "$e" "$d/.env" 2>/dev/null || true'
+          - >-
+            t=/opt/auplc/jupyter-ai.env.example;
+            e=/home/jovyan/.env;
+            if [ ! -e "$e" ] && [ -f "$t" ]; then cp "$t" "$e" && chmod 600 "$e"; fi;
+            d="$(pwd)";
+            [ "$d" = "/home/jovyan" ] || ln -sf "$e" "$d/.env" 2>/dev/null || true
   initContainers: []
   extraContainers: []
   allowPrivilegeEscalation: false

--- a/runtime/chart/values.yaml
+++ b/runtime/chart/values.yaml
@@ -521,7 +521,19 @@ singleuser:
     hub.jupyter.org/network-access-hub: "true"
   extraFiles: {}
   extraEnv: {}
-  lifecycleHooks: {}
+  # Seed a persistent ~/.env (for Jupyter AI / LiteLLM API keys) on first launch
+  # and symlink it into the server's working directory. Each course image sets a
+  # different, non-persistent WORKDIR as the JupyterLab root, where Jupyter AI
+  # reads its .env from; symlinking the persistent ~/.env there means students
+  # set their API key once and it survives across sessions and courses.
+  # Assumes the home PVC is mounted at /home/jovyan (storage.homeMountPath).
+  lifecycleHooks:
+    postStart:
+      exec:
+        command:
+          - "sh"
+          - "-c"
+          - 't=/opt/auplc/jupyter-ai.env.example; e=/home/jovyan/.env; if [ ! -e "$e" ] && [ -f "$t" ]; then cp "$t" "$e" && chmod 600 "$e"; fi; d="$(pwd)"; [ "$d" = "/home/jovyan" ] || ln -sf "$e" "$d/.env" 2>/dev/null || true'
   initContainers: []
   extraContainers: []
   allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Jupyter AI v3 reads its API-key `.env` from the JupyterLab server root, which in AUPLC is each course image's **non-persistent** `WORKDIR` (`/opt/workspace/<course>`). Keys had to be re-entered on every spawn and differed per course.
- Add a singleuser `postStart` hook that seeds a template `~/.env` onto the persistent home PVC on first launch and symlinks it into the working directory, so students set their API key **once** and it survives across sessions and courses.
- Ship a commented `.env` template (empty values) listing common LiteLLM provider key names, baked into the base image at `/opt/auplc/jupyter-ai.env.example`.

## Changes
- `dockerfiles/Base/jupyter-ai/dot-env.example` — new commented template with empty provider keys (OpenAI/Anthropic/Gemini/Mistral/Groq/Cohere/Together/HF/OpenRouter + custom proxy base URL).
- `dockerfiles/Base/Dockerfile.rocm` — copy template to `/opt/auplc/jupyter-ai.env.example` (inherited by all course images via `FROM auplc-base`).
- `runtime/chart/values.yaml` — `singleuser.lifecycleHooks.postStart` seeds `~/.env` (only if absent, `chmod 600`) and symlinks it into `$(pwd)`; skips when root is already `/home/jovyan` (git-clone spawns).

## Behaviour
- First spawn: `~/.env` seeded from template on the persistent PVC; never overwrites an existing file.
- UI "Add secret" / direct edits write through the symlink to `~/.env` → persisted.
- Works for both single-node (local-path) and multi-node (NFS) since both already mount the home PVC at `/home/jovyan`.

## Notes / deploy
- Requires `helm upgrade` (e.g. `auplc-installer rt upgrade`) for the Hub to pick up the new postStart hook, then a fresh spawn.
- Base **and** course images must be rebuilt so the template is present in course layers.
- Assumes the home PVC is mounted at `/home/jovyan` (`singleuser.storage.homeMountPath`).

## Test plan
- [ ] `helm upgrade`, stop + start a course server.
- [ ] In JupyterLab terminal: `ls -l "$(pwd)/.env" ~/.env` shows the symlink → `~/.env`.
- [ ] Add an API key via Jupyter AI settings; confirm it persists after stop/start.
- [ ] Switch to a different course; confirm the same key is picked up.
- [ ] Confirm `kubectl get pod <pod> -o jsonpath='{.spec.containers[0].lifecycle.postStart}'` shows the hook.

Made with [Cursor](https://cursor.com)