### PR TITLE
Include libavutil which was missing for FFmpeg

### DIFF
--- a/dockerfiles/Base/Dockerfile.rocm
+++ b/dockerfiles/Base/Dockerfile.rocm
@@ -129,6 +129,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   run-one \
   libatomic1 \
   unzip \
+  libavutil-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Including `libavutil` which was missing for FFmpeg. User reported that torchcodec couldn't decode the PushT videos

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Tested on local Kubernetes cluster
- [x] Documentation links updated
